### PR TITLE
MAGENTO2-364 cast param to string, because afterFilter() expects it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 ## [Unreleased]
 ### Fixed
 - sort order of products within categories
+- error in product export (Enterprise Edtition only)
 
 ## [2.9.15] - 2019-09-13
 ### Added

--- a/src/Helper/Product/Utility.php
+++ b/src/Helper/Product/Utility.php
@@ -449,6 +449,6 @@ class Utility
                 $description = $product->getDescription();
         }
 
-        return $this->filter->getPageFilter()->filter($description);
+        return $this->filter->getPageFilter()->filter((string)$description);
     }
 }


### PR DESCRIPTION
# Pull Request Template

## Description

MAGENTO2-364 cast param to string, because afterFilter() expects it

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I updated the CHANGELOG.md
