### PR TITLE
Bugfix/magento2 406 direct ship availability can

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 ### Added
 - Security enhancements
 
+### Fixed
+- Inventoryhandling for for version >= 2.3 
+
 ### Removed
 - Support for PHP < 7.1
 - Support for Magento < 2.2  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - Security enhancements
 
 ### Fixed
-- Inventory handling for for version >= 2.3 
+- Inventory handling for Magento version >= 2.3 
 
 ### Removed
 - Support for PHP < 7.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - Security enhancements
 
 ### Fixed
-- Inventoryhandling for for version >= 2.3 
+- Inventory handling for for version >= 2.3 
 
 ### Removed
 - Support for PHP < 7.1

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
     ],
     "psr-4": {
       "Shopgate\\Export\\": "src/",
-      "Shopgate\\Export\\Tests\\": "tests/"
+      "Shopgate\\Export\\Test\\": "src/Test/"
     }
   }
 }

--- a/src/Helper/Product/Stock/Utility.php
+++ b/src/Helper/Product/Stock/Utility.php
@@ -167,7 +167,6 @@ class Utility
                 ? $this->stockItem->setIsSaleable($product->getIsSalable())
                 : $this->stockItem->setIsSaleable(true);
 
-
         } catch (LocalizedException $exception) {
             $this->log->error(
                 "Can't handle stock of product with id: {$product->getId()}, message: " . $exception->getMessage()

--- a/src/Helper/Product/Stock/Utility.php
+++ b/src/Helper/Product/Stock/Utility.php
@@ -1,0 +1,156 @@
+<?php
+
+/**
+ * Copyright Shopgate Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @author    Shopgate Inc, 804 Congress Ave, Austin, Texas 78701 <interfaces@shopgate.com>
+ * @copyright Shopgate Inc
+ * @license   http://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
+ */
+
+namespace Shopgate\Export\Helper\Product\Stock;
+
+use Magento\Catalog\Model\Product as MageProduct;
+use Magento\CatalogInventory\Api\Data\StockItemInterfaceFactory;
+use Magento\CatalogInventory\Model\ResourceModel\Stock\Item as StockItemResource;
+use Magento\CatalogInventory\Model\Stock;
+use Magento\Framework\App\ObjectManager;
+use Magento\Framework\App\ProductMetadataInterface;
+use Magento\Store\Model\StoreManager;
+use Shopgate\Export\Model\Product\StockItemFactory as ProductStockItemFactory;
+
+class Utility
+{
+    /** @var ProductStockItemFactory */
+    protected $stockItem;
+
+    /** @var StockItem */
+    protected $productMetadata;
+
+    /** @var StockItemResource */
+    protected $stockItemResource;
+
+    /** @var StockItemInterfaceFactory */
+    protected $stockItemFactory;
+
+    /** @var StoreManager */
+    protected $storeManager;
+
+    /** @var var GetStockIdForCurrentWebsite */
+    protected $getStockIdForCurrentWebsite;
+
+    /** @var GetStockItemDataInterface */
+    protected $getStockItemData;
+
+    /** @var GetStockItemConfiguration */
+    protected $getStockItemConfiguration;
+
+    /**
+     * @param ProductStockItemFactory   $productStockItemFactory
+     * @param ProductMetadataInterface  $productMetadata
+     * @param StockItemInterfaceFactory $stockItemFactory
+     * @param StockItemResource         $stockItemResource
+     */
+    public function __construct(
+        ProductStockItemFactory $productStockItemFactory,
+        ProductMetadataInterface $productMetadata,
+        StockItemInterfaceFactory $stockItemFactory,
+        StockItemResource $stockItemResource,
+        StoreManager $storeManager
+    ) {
+        $this->stockItem         = $productStockItemFactory->create();
+        $this->productMetadata   = $productMetadata;
+        $this->stockItemResource = $stockItemResource;
+        $this->stockItemFactory  = $stockItemFactory;
+        $this->storeManager      = $storeManager;
+
+        $this->setDependencies();
+    }
+
+    /**
+     * Set the dependencies based on version
+     */
+    protected function setDependencies()
+    {
+        if (version_compare($this->getCurrentVersion(), '2.3.0', '>=')) {
+            $om                                = ObjectManager::getInstance();
+            $this->getStockItemData            = $om->get('Magento\\InventorySalesApi\\Model\\GetStockItemDataInterface');
+            $this->getStockIdForCurrentWebsite = $om->get('Magento\\InventoryCatalog\\Model\\GetStockIdForCurrentWebsite');
+            $this->getStockItemConfiguration   = $om->get('Magento\\InventoryExportStock\\Model\\GetStockItemConfiguration');
+        }
+    }
+
+    /**
+     * @return string
+     */
+    protected function getCurrentVersion()
+    {
+        return $this->productMetadata->getVersion();
+    }
+
+    /**
+     * @param MageProduct $product
+     *
+     * @return StockItem
+     * @throws \Magento\Framework\Exception\LocalizedException
+     */
+    public function getStockItem($product)
+    {
+        if (version_compare($this->getCurrentVersion(), '2.3.0', '>=')) {
+            $stockId         = $this->getStockIdForCurrentWebsite->execute();
+            $stockItemData   = $this->getStockItemData->execute($product->getSku(), $stockId);
+            $stockItemConfig = $this->getStockItemConfiguration->execute($product->getSku(), $stockId);
+
+            $this->stockItem->setStockQuantity((int)$stockItemData['quantity']);
+            $this->stockItem->setIsSaleable((bool)$stockItemData['is_salable']);
+            $this->stockItem->setUseStock((bool)$stockItemConfig->isManageStock());
+            $this->stockItem->setBackorders((bool)$stockItemConfig->getBackorders());
+            $this->stockItem->setMaximumOrderQuantity($stockItemConfig->getMaxSaleQty());
+            $this->stockItem->setMinimumOrderQuantity($stockItemConfig->getMinSaleQty());
+
+            return $this->stockItem;
+        }
+
+        $stockItem = $this->stockItemFactory->create();
+        $this->stockItemResource->loadByProductId(
+            $stockItem,
+            $product->getId(),
+            $this->storeManager->getWebsite()->getId()
+        );
+
+        $useStock = false;
+        if ($stockItem->getManageStock()) {
+            switch ($stockItem->getBackorders() && $stockItem->getIsInStock()) {
+                case Stock::BACKORDERS_YES_NONOTIFY:
+                case Stock::BACKORDERS_YES_NOTIFY:
+                    break;
+                default:
+                    $useStock = true;
+                    break;
+            }
+        }
+        $this->stockItem->setUseStock((bool)$useStock);
+        $this->stockItem->setBackorders((bool)$stockItem->getBackorders());
+        $this->stockItem->setStockQuantity((int)$stockItem->getQty());
+        $this->stockItem->setMaximumOrderQuantity($stockItem->getMaxSaleQty());
+        $this->stockItem->setMinimumOrderQuantity($stockItem->getMinSaleQty());
+
+        $useStock
+            ? $this->stockItem->setIsSaleable($product->getIsSalable())
+            : $this->stockItem->setIsSaleable(true);
+
+        return $this->stockItem;
+    }
+}

--- a/src/Helper/Product/Stock/Utility.php
+++ b/src/Helper/Product/Stock/Utility.php
@@ -41,7 +41,7 @@ class Utility
     /** @var ProductStockItemFactory */
     protected $stockItem;
 
-    /** @var StockItem */
+    /** @var ProductMetadataInterface */
     protected $productMetadata;
 
     /** @var StockItemResource */
@@ -53,13 +53,13 @@ class Utility
     /** @var StoreManager */
     protected $storeManager;
 
-    /** @var var GetStockIdForCurrentWebsite */
+    /** @noinspection PhpParamsInspection */
     protected $getStockIdForCurrentWebsite;
 
-    /** @var GetStockItemDataInterface */
+    /** @noinspection PhpParamsInspection */
     protected $getStockItemData;
 
-    /** @var GetStockItemConfiguration */
+    /** @noinspection PhpParamsInspection */
     protected $getStockItemConfiguration;
 
     /**
@@ -112,22 +112,28 @@ class Utility
     /**
      * @param MageProduct $product
      *
-     * @return \Shopgate\Export\Model\Product\StockItem|ProductStockItemFactory
-     * @throws LocalizedException
+     * @return ProductStockItemFactory
      */
     public function getStockItem($product)
     {
         try {
             if (version_compare($this->getCurrentVersion(), '2.3.0', '>=')) {
+                /** @noinspection PhpUndefinedMethodInspection */
                 $stockId         = $this->getStockIdForCurrentWebsite->execute();
+                /** @noinspection PhpUndefinedMethodInspection */
                 $stockItemData   = $this->getStockItemData->execute($product->getSku(), $stockId);
+                /** @noinspection PhpUndefinedMethodInspection */
                 $stockItemConfig = $this->getStockItemConfiguration->execute($product->getSku(), $stockId);
 
                 $this->stockItem->setStockQuantity((int)$stockItemData['quantity']);
                 $this->stockItem->setIsSaleable((bool)$stockItemData['is_salable']);
+                /** @noinspection PhpUndefinedMethodInspection */
                 $this->stockItem->setUseStock((bool)$stockItemConfig->isManageStock());
+                /** @noinspection PhpUndefinedMethodInspection */
                 $this->stockItem->setBackorders((bool)$stockItemConfig->getBackorders());
+                /** @noinspection PhpUndefinedMethodInspection */
                 $this->stockItem->setMaximumOrderQuantity($stockItemConfig->getMaxSaleQty());
+                /** @noinspection PhpUndefinedMethodInspection */
                 $this->stockItem->setMinimumOrderQuantity($stockItemConfig->getMinSaleQty());
 
                 return $this->stockItem;
@@ -161,11 +167,13 @@ class Utility
                 ? $this->stockItem->setIsSaleable($product->getIsSalable())
                 : $this->stockItem->setIsSaleable(true);
 
-            return $this->stockItem;
+
         } catch (LocalizedException $exception) {
             $this->log->error(
                 "Can't handle stock of product with id: {$product->getId()}, message: " . $exception->getMessage()
             );
         }
+
+        return $this->stockItem;
     }
 }

--- a/src/Helper/Product/Stock/Utility.php
+++ b/src/Helper/Product/Stock/Utility.php
@@ -166,7 +166,6 @@ class Utility
             $useStock
                 ? $this->stockItem->setIsSaleable($product->getIsSalable())
                 : $this->stockItem->setIsSaleable(true);
-
         } catch (LocalizedException $exception) {
             $this->log->error(
                 "Can't handle stock of product with id: {$product->getId()}, message: " . $exception->getMessage()

--- a/src/Helper/Product/Utility.php
+++ b/src/Helper/Product/Utility.php
@@ -28,10 +28,7 @@ use Magento\Catalog\Model\Product;
 use Magento\Catalog\Model\Product as MageProduct;
 use Magento\Catalog\Model\Product\Option;
 use Magento\Catalog\Model\Product\Visibility;
-use Magento\CatalogInventory\Api\Data\StockItemInterfaceFactory;
 use Magento\Cms\Model\Template\FilterProvider;
-use Magento\Framework\App\ProductMetadataInterface;
-use Magento\CatalogInventory\Model\ResourceModel\Stock\Item as StockItemResource;
 use Magento\Store\Model\StoreManager;
 use Magento\Tax\Model\Config as TaxConfig;
 use Magento\Tax\Model\TaxCalculation;
@@ -39,15 +36,13 @@ use Shopgate\Base\Api\Config\CoreInterface;
 use Shopgate\Export\Api\ExportInterface;
 use Shopgate\Export\Model\Config\Source\Description;
 use Shopgate\Export\Model\Export\Utility as ExportUtility;
-use Shopgate\Export\Model\Utility\StockItem;
 use Shopgate_Model_Catalog_CategoryPath;
 use Shopgate_Model_Catalog_Input;
 use Shopgate_Model_Catalog_Option;
 use Shopgate_Model_Catalog_Relation;
 use Shopgate_Model_Catalog_Validation;
 use Shopgate_Model_Catalog_Visibility;
-use Magento\Framework\App\ObjectManager;
-use Magento\CatalogInventory\Model\Stock;
+use Shopgate\Export\Model\Product\StockItemFactory;
 
 use Shopgate\Export\Helper\Product\Stock\Utility as StockUtility;
 
@@ -189,8 +184,7 @@ class Utility
     /**
      * @param MageProduct $product
      *
-     * @return StockItem
-     * @throws \Magento\Framework\Exception\LocalizedException
+     * @return StockItemFactory
      */
     public function getStockItem($product)
     {

--- a/src/Model/Export/Product.php
+++ b/src/Model/Export/Product.php
@@ -409,32 +409,17 @@ class Product extends Shopgate_Model_Catalog_Product
      */
     public function setStock()
     {
-        $stockItem = $this->helperProduct->getStockItem($this->item);
-        $stock     = new Shopgate_Model_Catalog_Stock();
-        $useStock  = false;
+        $stockItem       = $this->helperProduct->getStockItem($this->item);
+        $stockItemConfig = $this->helperProduct->getStockItemConfig($this->item);
 
-        if ($stockItem->getManageStock()) {
-            switch ($stockItem->getBackorders() && $stockItem->getIsInStock()) {
-                case Stock::BACKORDERS_YES_NONOTIFY:
-                case Stock::BACKORDERS_YES_NOTIFY:
-                    break;
-                default:
-                    $useStock = true;
-                    break;
-            }
-        }
+        $stock    = new Shopgate_Model_Catalog_Stock();
 
-        $stock->setUseStock($useStock);
-        $stock->setBackorders((bool) $stockItem->getBackorders());
-        $stock->setStockQuantity($stockItem->getQty());
-        $stock->setMaximumOrderQuantity($stockItem->getMaxSaleQty());
-        $stock->setMinimumOrderQuantity($stockItem->getMinSaleQty());
-
-        if ($stock->getUseStock()) {
-            $stock->setIsSaleable($this->item->getIsSalable());
-        } else {
-            $stock->setIsSaleable(true);
-        }
+        $stock->setUseStock((bool)$stockItemConfig->isManageStock());
+        $stock->setBackorders((bool)$stockItemConfig->getBackorders());
+        $stock->setStockQuantity((int)$stockItem['quantity']);
+        $stock->setMaximumOrderQuantity($stockItemConfig->getMaxSaleQty());
+        $stock->setMinimumOrderQuantity($stockItemConfig->getMinSaleQty());
+        $stock->setIsSaleable((bool)$stockItem['is_salable']);
 
         parent::setStock($stock);
     }

--- a/src/Model/Export/Product.php
+++ b/src/Model/Export/Product.php
@@ -28,6 +28,7 @@ use Magento\ConfigurableProduct\Model\Product\Type\Configurable;
 use Magento\Customer\Model\GroupManagement;
 use Magento\Directory\Helper\Data;
 use Magento\Framework\DataObject;
+use Magento\Framework\Exception\LocalizedException;
 use Magento\GroupedProduct\Model\Product\Type\Grouped;
 use Magento\Store\Model\Store;
 use Magento\Store\Model\StoreManagerInterface;
@@ -405,8 +406,10 @@ class Product extends Shopgate_Model_Catalog_Product
 
     /**
      * Set stock
+     *
+     * @throws LocalizedException
      */
-    public function setStock()
+    public function setStock(): void
     {
         $stockItem = $this->helperProduct->getStockItem($this->item);
         $stock     = new Shopgate_Model_Catalog_Stock();

--- a/src/Model/Export/Product.php
+++ b/src/Model/Export/Product.php
@@ -24,7 +24,6 @@ namespace Shopgate\Export\Model\Export;
 use Exception;
 use Magento\Catalog\Api\CategoryRepositoryInterface;
 use Magento\Catalog\Model\Product as MageProduct;
-use Magento\CatalogInventory\Model\Stock;
 use Magento\ConfigurableProduct\Model\Product\Type\Configurable;
 use Magento\Customer\Model\GroupManagement;
 use Magento\Directory\Helper\Data;

--- a/src/Model/Export/Product.php
+++ b/src/Model/Export/Product.php
@@ -409,17 +409,9 @@ class Product extends Shopgate_Model_Catalog_Product
      */
     public function setStock()
     {
-        $stockItem       = $this->helperProduct->getStockItem($this->item);
-        $stockItemConfig = $this->helperProduct->getStockItemConfig($this->item);
-
-        $stock    = new Shopgate_Model_Catalog_Stock();
-
-        $stock->setUseStock((bool)$stockItemConfig->isManageStock());
-        $stock->setBackorders((bool)$stockItemConfig->getBackorders());
-        $stock->setStockQuantity((int)$stockItem['quantity']);
-        $stock->setMaximumOrderQuantity($stockItemConfig->getMaxSaleQty());
-        $stock->setMinimumOrderQuantity($stockItemConfig->getMinSaleQty());
-        $stock->setIsSaleable((bool)$stockItem['is_salable']);
+        $stockItem = $this->helperProduct->getStockItem($this->item);
+        $stock     = new Shopgate_Model_Catalog_Stock();
+        $stock->setData($stockItem->getData());
 
         parent::setStock($stock);
     }

--- a/src/Model/Product/StockItem.php
+++ b/src/Model/Product/StockItem.php
@@ -46,7 +46,7 @@ class StockItem extends DataObject
      */
     public function getStockQuantity()
     {
-        return $this->setData(self::STOCK_QUANTITY);
+        return $this->getData(self::STOCK_QUANTITY);
     }
 
     /**
@@ -126,6 +126,6 @@ class StockItem extends DataObject
      */
     public function getMinimumOrderQuantity()
     {
-        return $this->setData(self::MINIMUM_ORDER_QUANTITY);
+        return $this->getData(self::MINIMUM_ORDER_QUANTITY);
     }
 }

--- a/src/Model/Product/StockItem.php
+++ b/src/Model/Product/StockItem.php
@@ -20,18 +20,25 @@
  * @license   http://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
-namespace Shopgate\Export\Model\Utility;
+namespace Shopgate\Export\Model\Product;
 
 use Magento\Framework\DataObject;
 
 class StockItem extends DataObject
 {
+    const MINIMUM_ORDER_QUANTITY = 'minimum_order_quantity';
+    const MAXIMUM_ORDER_QUANTITY = 'maximum_order_quantity';
+    const BACKORDERS             = 'backorders';
+    const USE_STOCk              = 'use_stock';
+    const IS_SALABLE             = 'is_salable';
+    const STOCK_QUANTITY         = 'stock_quantity';
+
     /**
      * @param int $stockQuantity
      */
-    public function setStockQuantity($stockQuantity)
+    public function setStockQuantity(int $stockQuantity)
     {
-        $this->setData('stock_quantity', $stockQuantity);
+        $this->setData(self::STOCK_QUANTITY, $stockQuantity);
     }
 
     /**
@@ -39,15 +46,15 @@ class StockItem extends DataObject
      */
     public function getStockQuantity()
     {
-        return $this->setData('stock_quantity');
+        return $this->setData(self::STOCK_QUANTITY);
     }
 
     /**
      * @param bool $isSaleable
      */
-    public function setIsSaleable($isSaleable)
+    public function setIsSaleable(bool $isSaleable)
     {
-        $this->setData('is_salable', $isSaleable);
+        $this->setData(self::IS_SALABLE, $isSaleable);
     }
 
     /**
@@ -55,15 +62,15 @@ class StockItem extends DataObject
      */
     public function getIsSaleable()
     {
-        return $this->getData('is_salable');
+        return $this->getData(self::IS_SALABLE);
     }
 
     /**
      * @param bool $useStock
      */
-    public function setUseStock($useStock)
+    public function setUseStock(bool $useStock)
     {
-        $this->setData('use_stock', $useStock);
+        $this->setData(self::USE_STOCk, $useStock);
     }
 
     /**
@@ -71,15 +78,15 @@ class StockItem extends DataObject
      */
     public function getUseStock()
     {
-        return $this->getData('use_stock');
+        return $this->getData(self::USE_STOCk);
     }
 
     /**
      * @param bool $backorders
      */
-    public function setBackorders($backorders)
+    public function setBackorders(bool $backorders)
     {
-        $this->setData('backorders', $backorders);
+        $this->setData(self::BACKORDERS, $backorders);
     }
 
     /**
@@ -87,15 +94,15 @@ class StockItem extends DataObject
      */
     public function getBackorders()
     {
-        return $this->getData('backorders');
+        return $this->getData(self::BACKORDERS);
     }
 
     /**
      * @param int $maximumOrderQuantity
      */
-    public function setMaximumOrderQuantity($maximumOrderQuantity)
+    public function setMaximumOrderQuantity(int $maximumOrderQuantity)
     {
-        $this->setData('maximum_order_quantity', $maximumOrderQuantity);
+        $this->setData(self::MAXIMUM_ORDER_QUANTITY, $maximumOrderQuantity);
     }
 
     /**
@@ -103,15 +110,15 @@ class StockItem extends DataObject
      */
     public function getMaximumOrderQuantity()
     {
-        return $this->getData('maximum_order_quantity');
+        return $this->getData(self::MAXIMUM_ORDER_QUANTITY);
     }
 
     /**
      * @param int $minimumOrderQuantity
      */
-    public function setMinimumOrderQuantity($minimumOrderQuantity)
+    public function setMinimumOrderQuantity(int $minimumOrderQuantity)
     {
-        $this->setData('minimum_order_quantity', $minimumOrderQuantity);
+        $this->setData(self::MINIMUM_ORDER_QUANTITY, $minimumOrderQuantity);
     }
 
     /**
@@ -119,6 +126,6 @@ class StockItem extends DataObject
      */
     public function getMinimumOrderQuantity()
     {
-        return $this->setData('minimum_order_quantity');
+        return $this->setData(self::MINIMUM_ORDER_QUANTITY);
     }
 }

--- a/src/Model/Shopgate/Product/StockItem.php
+++ b/src/Model/Shopgate/Product/StockItem.php
@@ -30,7 +30,7 @@ class StockItem extends DataObject
     public const MAXIMUM_ORDER_QUANTITY = 'maximum_order_quantity';
     public const BACKORDERS             = 'backorders';
     public const USE_STOCK              = 'use_stock';
-    public const IS_SALABLE             = 'is_salable';
+    public const IS_SALEABLE             = 'is_saleable';
     public const STOCK_QUANTITY         = 'stock_quantity';
 
     /**
@@ -54,7 +54,7 @@ class StockItem extends DataObject
      */
     public function setIsSaleable(bool $isSaleable): void
     {
-        $this->setData(self::IS_SALABLE, $isSaleable);
+        $this->setData(self::IS_SALEABLE, $isSaleable);
     }
 
     /**
@@ -62,7 +62,7 @@ class StockItem extends DataObject
      */
     public function getIsSaleable(): bool
     {
-        return $this->getData(self::IS_SALABLE);
+        return $this->getData(self::IS_SALEABLE);
     }
 
     /**

--- a/src/Model/Shopgate/Product/StockItem.php
+++ b/src/Model/Shopgate/Product/StockItem.php
@@ -30,7 +30,7 @@ class StockItem extends DataObject
     public const MAXIMUM_ORDER_QUANTITY = 'maximum_order_quantity';
     public const BACKORDERS             = 'backorders';
     public const USE_STOCK              = 'use_stock';
-    public const IS_SALEABLE             = 'is_saleable';
+    public const IS_SALEABLE            = 'is_saleable';
     public const STOCK_QUANTITY         = 'stock_quantity';
 
     /**

--- a/src/Model/Shopgate/Product/StockItem.php
+++ b/src/Model/Shopgate/Product/StockItem.php
@@ -20,23 +20,23 @@
  * @license   http://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
-namespace Shopgate\Export\Model\Product;
+namespace Shopgate\Export\Model\Shopgate\Product;
 
 use Magento\Framework\DataObject;
 
 class StockItem extends DataObject
 {
-    const MINIMUM_ORDER_QUANTITY = 'minimum_order_quantity';
-    const MAXIMUM_ORDER_QUANTITY = 'maximum_order_quantity';
-    const BACKORDERS             = 'backorders';
-    const USE_STOCk              = 'use_stock';
-    const IS_SALABLE             = 'is_salable';
-    const STOCK_QUANTITY         = 'stock_quantity';
+    public const MINIMUM_ORDER_QUANTITY = 'minimum_order_quantity';
+    public const MAXIMUM_ORDER_QUANTITY = 'maximum_order_quantity';
+    public const BACKORDERS             = 'backorders';
+    public const USE_STOCK              = 'use_stock';
+    public const IS_SALABLE             = 'is_salable';
+    public const STOCK_QUANTITY         = 'stock_quantity';
 
     /**
      * @param int $stockQuantity
      */
-    public function setStockQuantity(int $stockQuantity)
+    public function setStockQuantity(int $stockQuantity): void
     {
         $this->setData(self::STOCK_QUANTITY, $stockQuantity);
     }
@@ -44,7 +44,7 @@ class StockItem extends DataObject
     /**
      * @return int
      */
-    public function getStockQuantity()
+    public function getStockQuantity(): int
     {
         return $this->getData(self::STOCK_QUANTITY);
     }
@@ -52,7 +52,7 @@ class StockItem extends DataObject
     /**
      * @param bool $isSaleable
      */
-    public function setIsSaleable(bool $isSaleable)
+    public function setIsSaleable(bool $isSaleable): void
     {
         $this->setData(self::IS_SALABLE, $isSaleable);
     }
@@ -60,7 +60,7 @@ class StockItem extends DataObject
     /**
      * @return bool
      */
-    public function getIsSaleable()
+    public function getIsSaleable(): bool
     {
         return $this->getData(self::IS_SALABLE);
     }
@@ -68,23 +68,23 @@ class StockItem extends DataObject
     /**
      * @param bool $useStock
      */
-    public function setUseStock(bool $useStock)
+    public function setUseStock(bool $useStock): void
     {
-        $this->setData(self::USE_STOCk, $useStock);
+        $this->setData(self::USE_STOCK, $useStock);
     }
 
     /**
      * @return bool
      */
-    public function getUseStock()
+    public function getUseStock(): bool
     {
-        return $this->getData(self::USE_STOCk);
+        return $this->getData(self::USE_STOCK);
     }
 
     /**
      * @param bool $backorders
      */
-    public function setBackorders(bool $backorders)
+    public function setBackorders(bool $backorders): void
     {
         $this->setData(self::BACKORDERS, $backorders);
     }
@@ -92,7 +92,7 @@ class StockItem extends DataObject
     /**
      * @return bool
      */
-    public function getBackorders()
+    public function getBackorders(): bool
     {
         return $this->getData(self::BACKORDERS);
     }
@@ -100,7 +100,7 @@ class StockItem extends DataObject
     /**
      * @param int $maximumOrderQuantity
      */
-    public function setMaximumOrderQuantity(int $maximumOrderQuantity)
+    public function setMaximumOrderQuantity(int $maximumOrderQuantity): void
     {
         $this->setData(self::MAXIMUM_ORDER_QUANTITY, $maximumOrderQuantity);
     }
@@ -108,7 +108,7 @@ class StockItem extends DataObject
     /**
      * @return int
      */
-    public function getMaximumOrderQuantity()
+    public function getMaximumOrderQuantity(): int
     {
         return $this->getData(self::MAXIMUM_ORDER_QUANTITY);
     }
@@ -116,7 +116,7 @@ class StockItem extends DataObject
     /**
      * @param int $minimumOrderQuantity
      */
-    public function setMinimumOrderQuantity(int $minimumOrderQuantity)
+    public function setMinimumOrderQuantity(int $minimumOrderQuantity): void
     {
         $this->setData(self::MINIMUM_ORDER_QUANTITY, $minimumOrderQuantity);
     }
@@ -124,7 +124,7 @@ class StockItem extends DataObject
     /**
      * @return int
      */
-    public function getMinimumOrderQuantity()
+    public function getMinimumOrderQuantity(): int
     {
         return $this->getData(self::MINIMUM_ORDER_QUANTITY);
     }

--- a/src/Model/Utility/StockItem.php
+++ b/src/Model/Utility/StockItem.php
@@ -1,0 +1,124 @@
+<?php
+
+/**
+ * Copyright Shopgate Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @author    Shopgate Inc, 804 Congress Ave, Austin, Texas 78701 <interfaces@shopgate.com>
+ * @copyright Shopgate Inc
+ * @license   http://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
+ */
+
+namespace Shopgate\Export\Model\Utility;
+
+use Magento\Framework\DataObject;
+
+class StockItem extends DataObject
+{
+    /**
+     * @param int $stockQuantity
+     */
+    public function setStockQuantity($stockQuantity)
+    {
+        $this->setData('stock_quantity', $stockQuantity);
+    }
+
+    /**
+     * @return int
+     */
+    public function getStockQuantity()
+    {
+        return $this->setData('stock_quantity');
+    }
+
+    /**
+     * @param bool $isSaleable
+     */
+    public function setIsSaleable($isSaleable)
+    {
+        $this->setData('is_salable', $isSaleable);
+    }
+
+    /**
+     * @return bool
+     */
+    public function getIsSaleable()
+    {
+        return $this->getData('is_salable');
+    }
+
+    /**
+     * @param bool $useStock
+     */
+    public function setUseStock($useStock)
+    {
+        $this->setData('use_stock', $useStock);
+    }
+
+    /**
+     * @return bool
+     */
+    public function getUseStock()
+    {
+        return $this->getData('use_stock');
+    }
+
+    /**
+     * @param bool $backorders
+     */
+    public function setBackorders($backorders)
+    {
+        $this->setData('backorders', $backorders);
+    }
+
+    /**
+     * @return bool
+     */
+    public function getBackorders()
+    {
+        return $this->getData('backorders');
+    }
+
+    /**
+     * @param int $maximumOrderQuantity
+     */
+    public function setMaximumOrderQuantity($maximumOrderQuantity)
+    {
+        $this->setData('maximum_order_quantity', $maximumOrderQuantity);
+    }
+
+    /**
+     * @return int
+     */
+    public function getMaximumOrderQuantity()
+    {
+        return $this->getData('maximum_order_quantity');
+    }
+
+    /**
+     * @param int $minimumOrderQuantity
+     */
+    public function setMinimumOrderQuantity($minimumOrderQuantity)
+    {
+        $this->setData('minimum_order_quantity', $minimumOrderQuantity);
+    }
+
+    /**
+     * @return int
+     */
+    public function getMinimumOrderQuantity()
+    {
+        return $this->setData('minimum_order_quantity');
+    }
+}

--- a/src/Test/Integration/Helper/Product/HelperTest.php
+++ b/src/Test/Integration/Helper/Product/HelperTest.php
@@ -19,18 +19,19 @@
  * @license   http://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
-namespace Shopgate\Export\Tests\Integration\Helper\Product;
+namespace Shopgate\Export\Test\Integration\Helper\Product;
 
 use Magento\Catalog\Model\Product\Visibility;
 use Magento\Catalog\Model\ProductFactory;
 use Magento\Store\Model\StoreManagerInterface;
+use PHPUnit\Framework\TestCase;
 use Shopgate\Base\Tests\Bootstrap;
 use Shopgate\Export\Helper\Product\Utility;
 
 /**
  * @coversDefaultClass Shopgate\Export\Helper\Product\Utility
  */
-class HelperTest extends \PHPUnit\Framework\TestCase
+class HelperTest extends TestCase
 {
     /** @var StoreManagerInterface */
     protected $storeManager;

--- a/src/Test/Integration/Helper/Product/RetrieverTest.php
+++ b/src/Test/Integration/Helper/Product/RetrieverTest.php
@@ -19,16 +19,18 @@
  * @license   http://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
-namespace Shopgate\Export\Tests\Integration\Helper\Product;
+namespace Shopgate\Export\Test\Integration\Helper\Product;
 
 use Magento\Store\Model\StoreManagerInterface;
+use PHPUnit\Framework\TestCase;
 use Shopgate\Base\Tests\Bootstrap;
 use Shopgate\Export\Helper\Product\Retriever;
+use Shopgate\Export\Model\Export\Product;
 
 /**
  * @coversDefaultClass \Shopgate\Export\Helper\Product\Retriever
  */
-class RetrieverTest extends \PHPUnit\Framework\TestCase
+class RetrieverTest extends TestCase
 {
     /** @var StoreManagerInterface */
     protected $storeManager;
@@ -49,7 +51,7 @@ class RetrieverTest extends \PHPUnit\Framework\TestCase
      * Check if the created product can be pulled
      * individually by UID
      *
-     * @param   int $uid
+     * @param int $uid
      *
      * @covers ::getItems
      * @dataProvider uidProvider
@@ -59,7 +61,7 @@ class RetrieverTest extends \PHPUnit\Framework\TestCase
         $sgProducts = $this->class->getItems(null, null, [$uid]);
 
         foreach ($sgProducts as $sgProduct) {
-            /** @var \Shopgate\Export\Model\Export\Product $sgProduct */
+            /** @var Product $sgProduct */
             $this->assertEquals($uid, $sgProduct->getUid());
         }
     }

--- a/src/Test/Integration/Helper/TaxTest.php
+++ b/src/Test/Integration/Helper/TaxTest.php
@@ -20,21 +20,24 @@
  * @license   http://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
-namespace Shopgate\Export\Tests\Integration\Helper;
+namespace Shopgate\Export\Test\Integration\Helper;
 
 use Magento\Quote\Model\Quote\AddressFactory;
+use Magento\Quote\Model\QuoteFactory;
 use Magento\Store\Model\ScopeInterface;
 use Magento\Tax\Model\Config as TaxConfig;
+use PHPUnit\Framework\TestCase;
 use Shopgate\Base\Tests\Bootstrap;
 use Shopgate\Base\Tests\Integration\Db\ConfigManager;
+use Shopgate\Export\Helper\Tax;
 
-class TaxTest extends \PHPUnit\Framework\TestCase
+class TaxTest extends TestCase
 {
     /** @var ConfigManager */
     protected $cfgManager;
-    /** @var \Shopgate\Export\Helper\Tax */
+    /** @var Tax */
     protected $class;
-    /** @var \Magento\Quote\Model\QuoteFactory */
+    /** @var QuoteFactory */
     protected $quoteFactory;
     /** @var AddressFactory */
     protected $addressFactory;

--- a/src/Test/Integration/Model/Export/CategoryTest.php
+++ b/src/Test/Integration/Model/Export/CategoryTest.php
@@ -19,9 +19,10 @@
  * @license   http://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
-namespace Shopgate\Export\Tests\Integration\Model\Export;
+namespace Shopgate\Export\Test\Integration\Model\Export;
 
 use Magento\Catalog\Model\CategoryFactory;
+use PHPUnit\Framework\TestCase;
 use Shopgate\Base\Tests\Bootstrap;
 use Shopgate\Base\Tests\Integration\Db\ConfigManager;
 use Shopgate\Export\Api\ExportInterface;
@@ -30,7 +31,7 @@ use Shopgate\Export\Model\Export\CategoryFactory as ExportFactory;
 /**
  * @coversDefaultClass Shopgate\Export\Model\Export\Category
  */
-class CategoryTest extends \PHPUnit\Framework\TestCase
+class CategoryTest extends TestCase
 {
     /** @var ExportFactory */
     protected $sgCategoryFactory;

--- a/src/Test/Integration/Model/Export/ProductTest.php
+++ b/src/Test/Integration/Model/Export/ProductTest.php
@@ -197,7 +197,7 @@ class ProductTest extends TestCase
     }
 
     /**
-     * @return array
+     * @return string[]
      */
     public function inventoryDetailDataProvider(): array
     {

--- a/src/Test/Integration/Model/Export/ProductTest.php
+++ b/src/Test/Integration/Model/Export/ProductTest.php
@@ -121,7 +121,7 @@ class ProductTest extends TestCase
     /**
      * @throws NoSuchEntityException
      */
-    public function _testNotEmptyAttributeGroups(): void
+    public function testNotEmptyAttributeGroups(): void
     {
         $product = $this->productRepository->get('MH01');
         $this->subjectUnderTest->setItem($product)->setAttributeGroups();

--- a/src/Test/Integration/Model/Export/ProductTest.php
+++ b/src/Test/Integration/Model/Export/ProductTest.php
@@ -129,37 +129,6 @@ class ProductTest extends TestCase
     }
 
     /**
-     * Tests Group UIDs
-     *
-     * @return array
-     */
-    public function tierPriceUidProvider(): array
-    {
-        return [
-            'group 1'    => [
-                'expected'    => 1,
-                'tier prices' => [
-                    [
-                        'group_id' => '1',
-                        'qty'      => 0,
-                        'value'    => 0,
-                    ]
-                ]
-            ],
-            'all groups' => [
-                'expected'    => null,
-                'tier prices' => [
-                    [
-                        'group_id' => GroupManagement::CUST_GROUP_ALL,
-                        'qty'      => 0,
-                        'value'    => 0,
-                    ]
-                ]
-            ]
-        ];
-    }
-
-    /**
      * Test internal_order_info for products
      *
      * @return array

--- a/src/Test/Integration/Model/Export/ProductTest.php
+++ b/src/Test/Integration/Model/Export/ProductTest.php
@@ -24,6 +24,7 @@ namespace Shopgate\Export\Test\Integration\Model\Export;
 use Exception;
 use Magento\Catalog\Api\ProductRepositoryInterface;
 use Magento\Customer\Model\GroupManagement;
+use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\TestFramework\ObjectManager;
 use PHPUnit\Framework\TestCase;
@@ -118,7 +119,6 @@ class ProductTest extends TestCase
     }
 
     /**
-     * @covers ::setAttributeGroups
      * @throws NoSuchEntityException
      */
     public function testNotEmptyAttributeGroups(): void
@@ -129,9 +129,38 @@ class ProductTest extends TestCase
     }
 
     /**
+     * @param float  $expected
+     * @param string $sku
+     *
+     * @dataProvider inventoryDataProvider
+     * @throws NoSuchEntityException
+     * @throws LocalizedException
+     */
+    public function testInventory(float $expected, string $sku): void
+    {
+        $product = $this->productRepository->get($sku);
+        $this->subjectUnderTest->setItem($product)->setStock();
+        $stock = $this->subjectUnderTest->getStock();
+        $this->assertEquals($expected, $stock->getStockQuantity());
+    }
+
+    /**
+     * @return array
+     */
+    public function inventoryDataProvider(): array
+    {
+        return [
+            ['100', '24-MB01'],
+            ['0', 'MH01'],
+            ['0', '24-WG085_Group'],
+            ['0', '24-WG080']
+        ];
+    }
+
+    /**
      * Test internal_order_info for products
      *
-     * @return array
+     * @return string[]
      */
     public function orderInfoProvider(): array
     {

--- a/src/Test/Integration/Model/Export/ProductTest.php
+++ b/src/Test/Integration/Model/Export/ProductTest.php
@@ -22,10 +22,9 @@
 namespace Shopgate\Export\Test\Integration\Model\Export;
 
 use Exception;
-use Magento\Catalog\Api\Data\ProductTierPriceInterface;
-use Magento\Catalog\Model\Product;
-use Magento\Catalog\Model\ProductFactory;
+use Magento\Catalog\Api\ProductRepositoryInterface;
 use Magento\Customer\Model\GroupManagement;
+use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\TestFramework\ObjectManager;
 use PHPUnit\Framework\TestCase;
 use Shopgate\Export\Model\Export\Product as SubjectUnderTest;
@@ -35,79 +34,77 @@ use Shopgate_Model_Catalog_TierPrice;
  * @magentoAppIsolation enabled
  * @magentoDbIsolation  enabled
  * @magentoAppArea      frontend
+ * @magentoDataFixture  ../../../../vendor/shopgate/cart-integration-magento2-export/src/Test/Integration/fixtures/product_with_tier_pricing.php
  */
 class ProductTest extends TestCase
 {
     /** @var SubjectUnderTest */
     protected $subjectUnderTest;
-    /** @var ProductFactory */
-    protected $productFactory;
     /** * @var \Magento\Framework\App\ObjectManager */
     protected $objectManager;
+    /** @var ProductRepositoryInterface */
+    private $productRepository;
 
     /**
      * Setup
      */
     public function setUp()
     {
-        $this->objectManager    = ObjectManager::getInstance();
-        $this->subjectUnderTest = $this->objectManager->create(SubjectUnderTest::class);
-        $this->productFactory   = $this->objectManager->create(ProductFactory::class);
+        $this->objectManager     = ObjectManager::getInstance();
+        $this->subjectUnderTest  = $this->objectManager->create(SubjectUnderTest::class);
+        $this->productRepository = $this->objectManager->create(ProductRepositoryInterface::class);
     }
 
     /**
-     * @param int   $expected
-     * @param float $salePrice
-     * @param array $tierPrices
+     * Checking both fixed and percentage tier prices
+     * Check fixture for values, they go like this:
+     * 1) 1000-8$
+     * 2) 1000-20$
+     * 3) 1000-50%
      *
-     * @dataProvider tierPriceReductionProvider
      * @throws Exception
      */
-    public function testNonRuleTierPrices($expected, $salePrice, $tierPrices): void
+    public function testNonRuleTierPrices(): void
     {
-        $product = $this->createProduct()->setFinalPrice($salePrice);
-        $this->addTierPrices($product, $tierPrices);
+        $product = $this->productRepository->get('simple-test-product');
         $this->subjectUnderTest->setItem($product)->setPrice();
         $export = $this->subjectUnderTest->getPrice()->getTierPricesGroup();
 
         /** @var Shopgate_Model_Catalog_TierPrice $group */
-        $group = array_pop($export);
-        $this->assertEquals($expected, $group->getReduction());
+        foreach ($export as $group) {
+            $this->assertContains($group->getReduction(), ['992', '980', '500']);
+        }
     }
 
     /**
-     * @param $expected
-     * @param $tierPrices
-     *
-     * @dataProvider tierPriceUidProvider
      * @throws Exception
      */
-    public function testGroupUids($expected, $tierPrices): void
+    public function testGroupUids(): void
     {
-        $product = $this->createProduct();
-        $this->addTierPrices($product, $tierPrices);
+        $product = $this->productRepository->get('simple-test-product');
         $this->subjectUnderTest->setItem($product)->setPrice();
         $export = $this->subjectUnderTest->getPrice()->getTierPricesGroup();
 
-        /** @var Shopgate_Model_Catalog_TierPrice $group */
-        $group = array_pop($export);
-        $this->assertEquals($expected, $group->getCustomerGroupUid());
+        $this->assertEquals($export[1]->getCustomerGroupUid(), (string) GroupManagement::NOT_LOGGED_IN_ID);
+        $this->assertEquals($export[2]->getCustomerGroupUid(), '1');
     }
 
     /**
-     * @param string $expectedJson
-     * @param int    $productId
+     * @param string $expectedType
+     * @param int    $sku
      *
      * @dataProvider orderInfoProvider
      * @throws Exception
      */
-    public function testOrderInfoJson($expectedJson, $productId): void
+    public function testOrderInfoJson($expectedType, $sku): void
     {
-        $product = $this->createProduct()->load($productId);
+        $product = $this->productRepository->get($sku);
         $this->subjectUnderTest->setItem($product)->setInternalOrderInfo();
         $orderInfo = $this->subjectUnderTest->getInternalOrderInfo();
         $this->assertJson($orderInfo);
-        $this->assertEquals($expectedJson, $orderInfo);
+        /** @noinspection PhpComposerExtensionStubsInspection */
+        $info = json_decode($orderInfo, true);
+        $this->assertEquals($expectedType, $info['item_type']);
     }
 
     /**
@@ -115,52 +112,20 @@ class ProductTest extends TestCase
      */
     public function testSetWeight(): void
     {
-        $product = $this->createProduct();
+        $product = $this->productRepository->get('simple-test-product');
         $this->subjectUnderTest->setItem($product)->setWeight();
-        $this->assertEquals($product->getData('weight'), $this->subjectUnderTest->getWeight());
+        $this->assertEquals(15.5, $this->subjectUnderTest->getWeight());
     }
 
     /**
      * @covers ::setAttributeGroups
+     * @throws NoSuchEntityException
      */
     public function testNotEmptyAttributeGroups(): void
     {
-        $product = $this->createProduct()->load(83);
+        $product = $this->productRepository->get('MH01');
         $this->subjectUnderTest->setItem($product)->setAttributeGroups();
         $this->assertNotEmpty($this->subjectUnderTest->getAttributeGroups());
-    }
-
-    /**
-     * Tests reductions
-     *
-     * @return array
-     */
-    public function tierPriceReductionProvider(): array
-    {
-        return [
-            '5 off'    => [
-                'expected'    => 5,
-                'final price' => 20,
-                'tier prices' => [
-                    [
-                        'group_id' => '1',
-                        'qty'      => '4',
-                        'value'    => '15',
-                    ]
-                ]
-            ],
-            '100% off' => [
-                'expected'    => 0,
-                'final price' => 20,
-                'tier prices' => [
-                    [
-                        'group_id' => '1',
-                        'qty'      => '4',
-                        'value'    => '20',
-                    ]
-                ]
-            ]
-        ];
     }
 
     /**
@@ -199,80 +164,13 @@ class ProductTest extends TestCase
      *
      * @return array
      */
-    public function orderInfoProvider()
+    public function orderInfoProvider(): array
     {
         return [
-            'simple product order info #1'     => ['{"store_view_id":"1","product_id":"1","item_type":"simple"}', 1],
-            'simple product order info #2'     => ['{"store_view_id":"1","product_id":"2","item_type":"simple"}', 2],
-            'config product order info #67'    => [
-                '{"store_view_id":"1","product_id":"67","item_type":"configurable"}',
-                67
-            ],
-            'config product order info #83'    => [
-                '{"store_view_id":"1","product_id":"83","item_type":"configurable"}',
-                83
-            ],
-            'grouped product order info #2046' => [
-                '{"store_view_id":"1","product_id":"2046","item_type":"grouped"}',
-                2046
-            ]
+            'simple product order for simple'       => ['simple', '24-MB01'],
+            'config product order for configurable' => ['configurable', 'MH01'],
+            'grouped product order for grouped'     => ['grouped', '24-WG085_Group'],
+            'grouped product order for bundled '    => ['bundle', '24-WG080']
         ];
-    }
-
-    /**
-     * Creates a simple product
-     *
-     * @return Product
-     * @throws Exception
-     */
-    private function createProduct()
-    {
-        /** @var Product $categoryFactory */
-        $product = $this->productFactory->create();
-        $product->setName('Test Product')
-                ->setTypeId('simple')
-                ->setAttributeSetId(4)
-                ->setSku('test-SKU')
-                ->setWebsiteIds([(1)])
-                ->setVisibility(4)
-                ->setPrice(50)
-                ->setWeight(23.5)
-                ->setData('image', '/testimg/test.jpg')
-                ->setData('small_image', '/testimg/test.jpg')
-                ->setData('thumbnail', '/testimg/test.jpg')
-                ->setData(
-                    'stock_data',
-                    [
-                        'use_config_manage_stock' => 0,
-                        'manage_stock'            => 1,
-                        'min_sale_qty'            => 1,
-                        'max_sale_qty'            => 2,
-                        'is_in_stock'             => 1,
-                        'qty'                     => 100
-                    ]
-                );
-
-        return $product;
-    }
-
-    /**
-     * Helps add tier prices to the product
-     *
-     * @param Product $product
-     * @param array   $tierPrices
-     */
-    private function addTierPrices(Product $product, array $tierPrices): void
-    {
-        $nodes = [];
-        foreach ($tierPrices as $tierPrice) {
-            /** @var ProductTierPriceInterface $tierPriceNode */
-            $tierPriceNode = $this->objectManager->create(ProductTierPriceInterface::class);
-            $nodes[]       = $tierPriceNode
-                ->setCustomerGroupId($tierPrice['group_id'])
-                ->setQty($tierPrice['qty'])
-                ->setValue($tierPrice['value']);
-        }
-
-        $product->setTierPrices($nodes);
     }
 }

--- a/src/Test/Integration/Model/Export/ProductTest.php
+++ b/src/Test/Integration/Model/Export/ProductTest.php
@@ -121,7 +121,7 @@ class ProductTest extends TestCase
     /**
      * @throws NoSuchEntityException
      */
-    public function testNotEmptyAttributeGroups(): void
+    public function _testNotEmptyAttributeGroups(): void
     {
         $product = $this->productRepository->get('MH01');
         $this->subjectUnderTest->setItem($product)->setAttributeGroups();
@@ -151,9 +151,59 @@ class ProductTest extends TestCase
     {
         return [
             ['100', '24-MB01'],
-            ['0', 'MH01'],
-            ['0', '24-WG085_Group'],
-            ['0', '24-WG080']
+            ['0', 'MH01'], // Config
+            ['0', '24-WG085_Group'], // Group
+            ['0', '24-WG080'],
+            ['100', '24-WB07'],
+            ['100', 'MH01-XS-Black'], // Simple of config
+            ['0', '24-WG080'], // Bundle
+            ['100', '24-WG085'], // Simple 1 of bundle
+            ['100', '24-WG081-blue'], // Simple 2 of bundle
+            ['100', '243-MB04'], // Giftcard with stock
+        ];
+    }
+
+    /**
+     * @param string $sku
+     * @param float  $qty
+     * @param int    $maximumOrderQuantity
+     * @param int    $minimumOrderQuantity
+     * @param bool   $backOrders
+     * @param bool   $isSaleable
+     * @param bool   $useStock
+     *
+     * @dataProvider inventoryDetailDataProvider
+     * @throws LocalizedException
+     * @throws NoSuchEntityException
+     */
+    public function testInventoryDetail(
+        string $sku,
+        float $qty,
+        int $maximumOrderQuantity,
+        int $minimumOrderQuantity,
+        bool $backOrders,
+        bool $isSaleable,
+        bool $useStock
+    ): void {
+        $product = $this->productRepository->get($sku);
+        $this->subjectUnderTest->setItem($product)->setStock();
+        $stock = $this->subjectUnderTest->getStock();
+        $this->assertEquals($qty, $stock->getStockQuantity());
+        $this->assertEquals($maximumOrderQuantity, $stock->getMaximumOrderQuantity());
+        $this->assertEquals($minimumOrderQuantity, $stock->getMinimumOrderQuantity());
+        $this->assertEquals($backOrders, $stock->getBackorders());
+        $this->assertEquals($isSaleable, $stock->getIsSaleable());
+        $this->assertEquals($useStock, $stock->getUseStock());
+    }
+
+    /**
+     * @return array
+     */
+    public function inventoryDetailDataProvider(): array
+    {
+        return [
+            ['24-MB01' , '100', '10000', '1', '0', '1', '1'], // Simple
+            ['MH01' , '0', '10000', '1', '0', '1', '1'] // Config
         ];
     }
 

--- a/src/Test/Integration/Model/Export/ProductTest.php
+++ b/src/Test/Integration/Model/Export/ProductTest.php
@@ -145,7 +145,7 @@ class ProductTest extends TestCase
     }
 
     /**
-     * @return array
+     * @return string[]
      */
     public function inventoryDataProvider(): array
     {

--- a/src/Test/Integration/Model/Export/UtilityTest.php
+++ b/src/Test/Integration/Model/Export/UtilityTest.php
@@ -19,18 +19,20 @@
  * @license   http://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
-namespace Shopgate\Export\Tests\Integration\Model\Export;
+namespace Shopgate\Export\Test\Integration\Model\Export;
 
+use PHPUnit\Framework\TestCase;
 use Shopgate\Base\Api\Config\SgCoreInterface;
 use Shopgate\Base\Tests\Bootstrap;
 use Shopgate\Base\Tests\Integration\Db\ConfigManager;
+use Shopgate\Export\Model\Export\Utility;
 
 /**
  * @coversDefaultClass Shopgate\Export\Model\Export\Utility
  */
-class UtilityTest extends \PHPUnit\Framework\TestCase
+class UtilityTest extends TestCase
 {
-    /** @var  \Shopgate\Export\Model\Export\Utility */
+    /** @var  Utility */
     protected $class;
     /** @var  ConfigManager */
     protected $cfgManager;

--- a/src/Test/Integration/Model/Service/ExportTest.php
+++ b/src/Test/Integration/Model/Service/ExportTest.php
@@ -20,16 +20,22 @@
  * @license   http://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
-namespace Integration\Model\Service;
+namespace Shopgate\Export\Test\Integration;
 
+use Magento\Framework\Exception\CouldNotSaveException;
+use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\Quote\Model\Quote;
+use PHPUnit\Framework\TestCase;
 use Shopgate\Base\Tests\Bootstrap;
 use Shopgate\Base\Tests\Integration\Db\StockManager;
 use Shopgate\Export\Helper\Cart;
+use Zend_Json_Decoder;
+use Zend_Json_Exception;
 
 /**
- * @coversDefaultClass Shopgate\Export\Model\Service\Export
+ * @coversDefaultClass \Shopgate\Export\Model\Service\Export
  */
-class Export extends \PHPUnit\Framework\TestCase
+class ExportTest extends TestCase
 {
 
     /**
@@ -53,21 +59,19 @@ class Export extends \PHPUnit\Framework\TestCase
      * @covers       ::checkCartRaw
      * @covers       Cart::__construct
      * @covers       Cart::loadSupportedMethods
-     * @covers       Cart::loadQuoteFields
      * @covers       Cart::getItems
      * @covers       Quote::setItems
      * @covers       Quote::setCustomer
-     * @covers       Quote::cleanup
      *
      * @dataProvider allProductProvider
      *
-     * @throws \Magento\Framework\Exception\CouldNotSaveException
-     * @throws \Magento\Framework\Exception\NoSuchEntityException
-     * @throws \Zend_Json_Exception
+     * @throws CouldNotSaveException
+     * @throws NoSuchEntityException
+     * @throws Zend_Json_Exception
      */
     public function testCheckCartItems($expected, $sgCart)
     {
-        $internalInfo = \Zend_Json_Decoder::decode($sgCart['cart']['items'][0]['internal_order_info']);
+        $internalInfo = Zend_Json_Decoder::decode($sgCart['cart']['items'][0]['internal_order_info']);
         $this->stockManager->setStockWebsite($internalInfo['product_id']);
 
         /** @var \Shopgate\Export\Model\Service\Export $class */
@@ -340,7 +344,7 @@ class Export extends \PHPUnit\Framework\TestCase
     public function removeQuoteItems()
     {
         //todo-sg: does not clear quote correctly between tests
-        /** @var \Magento\Quote\Model\Quote $quote */
+        /** @var Quote $quote */
         $quote = Bootstrap::getObjectManager()->get('Magento\Quote\Model\Quote');
         $quote->removeAllItems();
         $quote->isDeleted(false);
@@ -354,13 +358,13 @@ class Export extends \PHPUnit\Framework\TestCase
      *
      * @dataProvider couponProvider
      *
-     * @throws \Magento\Framework\Exception\CouldNotSaveException
-     * @throws \Magento\Framework\Exception\NoSuchEntityException
-     * @throws \Zend_Json_Exception
+     * @throws CouldNotSaveException
+     * @throws NoSuchEntityException
+     * @throws Zend_Json_Exception
      */
     public function testCheckCartCoupons($expected, $cart)
     {
-        $internalInfo = \Zend_Json_Decoder::decode($cart['cart']['items'][0]['internal_order_info']);
+        $internalInfo = Zend_Json_Decoder::decode($cart['cart']['items'][0]['internal_order_info']);
         $this->stockManager->setStockWebsite($internalInfo['product_id']);
 
         /** @var \Shopgate\Export\Model\Service\Export $class */

--- a/src/Test/Integration/fixtures/product_with_tier_pricing.php
+++ b/src/Test/Integration/fixtures/product_with_tier_pricing.php
@@ -1,0 +1,67 @@
+<?php
+
+/**
+ * Copyright Shopgate Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @author    Shopgate Inc, 804 Congress Ave, Austin, Texas 78701 <interfaces@shopgate.com>
+ * @copyright 2019 Shopgate Inc
+ * @license   http://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
+ */
+
+use Magento\Catalog\Model\Product;
+use Magento\Catalog\Model\Product\Attribute\Source\Status;
+use Magento\Catalog\Model\Product\Visibility;
+use Magento\Customer\Model\GroupManagement;
+use Magento\TestFramework\Helper\Bootstrap;
+
+/** @var $product Product */
+$product = Bootstrap::getObjectManager()->create(Product::class);
+$product->setTypeId('simple')
+        ->setAttributeSetId(4)
+        ->setWebsiteIds([1])
+        ->setName('Simple Product')
+        ->setPrice(1000)
+        ->setFinalPrice(1000)
+        ->setSku('simple-test-product')
+        ->setVisibility(Visibility::VISIBILITY_BOTH)
+        ->setStatus(Status::STATUS_ENABLED)
+        ->setWeight(15.5)
+        ->setStockData(['use_config_manage_stock' => 1, 'qty' => 100, 'is_qty_decimal' => 0, 'is_in_stock' => 1])
+        ->setTierPrice(
+            [
+                [
+                    'website_id'       => 0,
+                    'cust_group'       => GroupManagement::CUST_GROUP_ALL,
+                    'price_qty'        => 2,
+                    'price'            => 8,
+                    'percentage_value' => 0
+                ],
+                [
+                    'website_id'       => 0,
+                    'cust_group'       => 1,
+                    'price_qty'        => 5,
+                    'price'            => 50,
+                    'percentage_value' => 50
+                ],
+                [
+                    'website_id'       => 0,
+                    'cust_group'       => GroupManagement::NOT_LOGGED_IN_ID,
+                    'price_qty'        => 3,
+                    'price'            => 20,
+                    'percentage_value' => 0
+                ],
+            ]
+        )
+        ->save();

--- a/src/Test/Unit/Helper/Cron/UtilityTest.php
+++ b/src/Test/Unit/Helper/Cron/UtilityTest.php
@@ -23,12 +23,15 @@ namespace Shopgate\Export\Test\Unit\Helper\Cron;
 
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
 use Magento\Sales\Model\Order;
+use PHPUnit\Framework\TestCase;
+use PHPUnit_Framework_MockObject_MockObject;
 use Shopgate\Export\Helper\Cron\Utility as CronHelper;
+use ShopgateOrderItem;
 
 /**
  * @coversDefaultClass \Shopgate\Export\Helper\Product\Utility
  */
-class UtilityTest extends \PHPUnit\Framework\TestCase
+class UtilityTest extends TestCase
 {
     /** @var ObjectManager */
     private $objectManager;
@@ -41,7 +44,7 @@ class UtilityTest extends \PHPUnit\Framework\TestCase
     public function setUp()
     {
         $this->objectManager = new ObjectManager($this);
-        /** @var \Shopgate\Export\Helper\Cron\Utility $cronHelper */
+        /** @var CronHelper $cronHelper */
         $this->cronHelper = $this->objectManager->getObject(CronHelper::class);
     }
 
@@ -53,16 +56,16 @@ class UtilityTest extends \PHPUnit\Framework\TestCase
      */
     public function testHasShippedItems($getQtyShipped, $expectedResult)
     {
-        /** @var Order|\PHPUnit_Framework_MockObject_MockObject $orderStub */
+        /** @var Order|PHPUnit_Framework_MockObject_MockObject $orderStub */
         $orderStub = $this->getTestDouble(Order::class);
-        /** @var Order\Item|\PHPUnit_Framework_MockObject_MockObject $orderItemStub */
+        /** @var Order\Item|PHPUnit_Framework_MockObject_MockObject $orderItemStub */
         $orderItemStub = $this->getTestDouble(Order\Item::class);
 
         $orderItemStub->method('getQtyShipped')
-            ->willReturn($getQtyShipped);
+                      ->willReturn($getQtyShipped);
 
         $orderStub->method('getItemsCollection')
-            ->willReturn([$orderItemStub]);
+                  ->willReturn([$orderItemStub]);
 
         $result = $this->cronHelper->hasShippedItems($orderStub);
         $this->assertEquals($expectedResult, $result);
@@ -75,12 +78,14 @@ class UtilityTest extends \PHPUnit\Framework\TestCase
     {
         $productId = 2;
 
-        /** @var \ShopgateOrderItem|\PHPUnit_Framework_MockObject_MockObject $orderItemStub */
-        $orderItemStub = $this->getTestDouble(\ShopgateOrderItem::class);
+        /** @var ShopgateOrderItem|PHPUnit_Framework_MockObject_MockObject $orderItemStub */
+        $orderItemStub = $this->getTestDouble(ShopgateOrderItem::class);
         $orderItemStub->method('getInternalOrderInfo')
-            ->willReturn([
-                'product_id' => $productId
-            ]);
+                      ->willReturn(
+                          [
+                              'product_id' => $productId
+                          ]
+                      );
 
         $result = $this->cronHelper->findItemByProductId([$orderItemStub], $productId);
 
@@ -95,12 +100,14 @@ class UtilityTest extends \PHPUnit\Framework\TestCase
      */
     public function testFindItemByProductIdFails($searchedProductId, $productId)
     {
-        /** @var \ShopgateOrderItem|\PHPUnit_Framework_MockObject_MockObject $orderItemStub */
-        $orderItemStub = $this->getTestDouble(\ShopgateOrderItem::class);
+        /** @var ShopgateOrderItem|PHPUnit_Framework_MockObject_MockObject $orderItemStub */
+        $orderItemStub = $this->getTestDouble(ShopgateOrderItem::class);
         $orderItemStub->method('getInternalOrderInfo')
-            ->willReturn([
-                'product_id' => $productId
-            ]);
+                      ->willReturn(
+                          [
+                              'product_id' => $productId
+                          ]
+                      );
 
         $result = $this->cronHelper->findItemByProductId([$orderItemStub], $searchedProductId);
 
@@ -113,9 +120,9 @@ class UtilityTest extends \PHPUnit\Framework\TestCase
     public function findItemProvider()
     {
         return [
-            'Should not find product by Id, because of null as product id' => [null, 2],
+            'Should not find product by Id, because of null as product id'         => [null, 2],
             'Should not find product by Id, because of empty string as product id' => ['', 2],
-            'Should not find product by Id, because of id mismatch' => [1, 2]
+            'Should not find product by Id, because of id mismatch'                => [1, 2]
         ];
     }
 
@@ -126,20 +133,20 @@ class UtilityTest extends \PHPUnit\Framework\TestCase
     {
         return [
             'null items to ship' => [null, false],
-            '0 items to ship' => [0, false],
-            '1 item to ship' => [1, true]
+            '0 items to ship'    => [0, false],
+            '1 item to ship'     => [1, true]
         ];
     }
 
     /**
      * @param string $class
      *
-     * @return \PHPUnit_Framework_MockObject_MockObject
+     * @return PHPUnit_Framework_MockObject_MockObject
      */
     private function getTestDouble($class)
     {
         return $this->getMockBuilder($class)
-            ->disableOriginalConstructor()
-            ->getMock();
+                    ->disableOriginalConstructor()
+                    ->getMock();
     }
 }

--- a/src/Test/Unit/Helper/Export/Product/HelperTest.php
+++ b/src/Test/Unit/Helper/Export/Product/HelperTest.php
@@ -23,11 +23,14 @@ namespace Shopgate\Export\Test\Unit\Helper\Export\Product;
 
 use Magento\Catalog\Model\Product;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
+use PHPUnit\Framework\TestCase;
+use Shopgate\Export\Helper\Product\Utility;
+use Shopgate_Model_Catalog_Relation;
 
 /**
- * @coversDefaultClass \Shopgate\Export\Helper\Product\Utility
+ * @coversDefaultClass Utility
  */
-class HelperTest extends \PHPUnit\Framework\TestCase
+class HelperTest extends TestCase
 {
 
     /**
@@ -35,7 +38,7 @@ class HelperTest extends \PHPUnit\Framework\TestCase
      */
     private $objectManager;
     /**
-     * @var \Shopgate\Export\Helper\Product\Utility
+     * @var Utility
      */
     private $helper;
 
@@ -146,7 +149,7 @@ class HelperTest extends \PHPUnit\Framework\TestCase
     public function testCreateRelationProducts($relatedIds, $type)
     {
         $relationModel = $this->helper->createRelationProducts($relatedIds, $type);
-        $this->assertInstanceOf(\Shopgate_Model_Catalog_Relation::class, $relationModel);
+        $this->assertInstanceOf(Shopgate_Model_Catalog_Relation::class, $relationModel);
         $this->assertEquals($type, $relationModel->getType());
         $this->assertEquals($relatedIds, $relationModel->getValues());
     }

--- a/src/Test/Unit/Model/Export/ProductTest.php
+++ b/src/Test/Unit/Model/Export/ProductTest.php
@@ -21,37 +21,29 @@
 
 namespace Shopgate\Export\Test\Unit\Model\Export;
 
+use ArrayIterator;
+use Exception;
 use Magento\Catalog\Model\Product;
 use Magento\ConfigurableProduct\Model\Product\Type\Configurable;
 use Magento\Framework\App\Config;
+use Magento\Framework\Data\Collection;
+use Magento\Framework\DataObject;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
 use Magento\GroupedProduct\Model\Product\Type\Grouped;
 use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
 use Shopgate\Base\Api\Config\CoreInterface;
 use Shopgate\Export\Model\Config\Source\Description;
 
 /**
  * @coversDefaultClass \Shopgate\Export\Model\Export\Product
  */
-class ProductTest extends \PHPUnit\Framework\TestCase
+class ProductTest extends TestCase
 {
     /**
      * @var ObjectManager
      */
     private $objectManager;
-
-    /**
-     * @return MockObject
-     */
-    private function getProductDouble()
-    {
-        $productDouble = $this
-            ->getMockBuilder(Product::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        return $productDouble;
-    }
 
     /**
      * Load object manager for initialization
@@ -74,26 +66,26 @@ class ProductTest extends \PHPUnit\Framework\TestCase
     {
         $this->markTestIncomplete('Expected strings not yet returned by the stub');
         $configValueStub = $this->getMockBuilder(Config\Value::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+                                ->disableOriginalConstructor()
+                                ->getMock();
 
         $configValueStub->method('getValue')
-            ->will($this->returnValue($descConfig));
+                        ->will($this->returnValue($descConfig));
 
         $scopeConfigStub = $this->getMockBuilder(CoreInterface::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+                                ->disableOriginalConstructor()
+                                ->getMock();
 
         $scopeConfigStub->method('getConfigByPath')
-            ->will($this->returnValue($configValueStub));
+                        ->will($this->returnValue($configValueStub));
 
         $productStub = $this->getProductDouble();
 
         $productStub->method('getDescription')
-            ->will($this->returnValue($longDesc));
+                    ->will($this->returnValue($longDesc));
 
         $productStub->method('getShortDescription')
-            ->will($this->returnValue($shortDesc));
+                    ->will($this->returnValue($shortDesc));
 
         /** @var \Shopgate\Export\Model\Export\Product $exportModel */
         $exportModel = $this->objectManager->getObject(
@@ -120,7 +112,7 @@ class ProductTest extends \PHPUnit\Framework\TestCase
         $productStub = $this->getProductDouble();
 
         $productStub->method('getTypeId')
-            ->will($this->returnValue($productType));
+                    ->will($this->returnValue($productType));
 
         /** @var \Shopgate\Export\Model\Export\Product $exportModel */
         $exportModel = $this->objectManager->getObject(
@@ -143,7 +135,7 @@ class ProductTest extends \PHPUnit\Framework\TestCase
         $productStub = $this->getProductDouble();
 
         $productStub->method('getTypeId')
-            ->will($this->returnValue($productType));
+                    ->will($this->returnValue($productType));
 
         /** @var \Shopgate\Export\Model\Export\Product $exportModel */
         $exportModel = $this->objectManager->getObject(
@@ -166,10 +158,10 @@ class ProductTest extends \PHPUnit\Framework\TestCase
     {
         $productStub = $this->getProductDouble();
         $productStub->method('getMediaGalleryImages')
-            ->willReturn($this->getTestCollection($imageData));
+                    ->willReturn($this->getTestCollection($imageData));
 
         $productStub->method('getData')
-            ->will($this->returnValueMap([['small_image', null, $smallImagePath]]));
+                    ->will($this->returnValueMap([['small_image', null, $smallImagePath]]));
 
         /** @var \Shopgate\Export\Model\Export\Product $exportModel */
         $exportModel = $this->objectManager->getObject(
@@ -208,44 +200,6 @@ class ProductTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
-     * @param string $url
-     * @param int    $position
-     *
-     * @return \Magento\Framework\DataObject
-     *
-     * @throws \Exception
-     */
-    private function createImageObject($url, $position)
-    {
-        return new \Magento\Framework\DataObject([
-            'id'       => random_int(0, 10000),
-            'url'      => $url,
-            'file'     => $url,
-            'position' => $position,
-            'tile'     => 'fake image',
-            'alt'      => 'fake image',
-        ]);
-    }
-
-    /**
-     * @param array $items
-     *
-     * @return MockObject
-     */
-    private function getTestCollection($items)
-    {
-        $collection = $this
-            ->getMockBuilder(\Magento\Framework\Data\Collection::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $iterator = new \ArrayIterator($items);
-        $collection->expects($this->any())->method('getIterator')->will($this->returnValue($iterator));
-
-        return $collection;
-    }
-
-    /**
      * @return array
      */
     public function productTypeProvider()
@@ -279,5 +233,58 @@ class ProductTest extends \PHPUnit\Framework\TestCase
             'default long description' => ['long', 'test', 'long', 'short'],
             'return short description' => ['short', Description::ID_SHORT_DESCRIPTION, 'long', 'short'],
         ];
+    }
+
+    /**
+     * @return MockObject
+     */
+    private function getProductDouble()
+    {
+        $productDouble = $this
+            ->getMockBuilder(Product::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        return $productDouble;
+    }
+
+    /**
+     * @param string $url
+     * @param int    $position
+     *
+     * @return DataObject
+     *
+     * @throws Exception
+     */
+    private function createImageObject($url, $position)
+    {
+        return new DataObject(
+            [
+                'id'       => random_int(0, 10000),
+                'url'      => $url,
+                'file'     => $url,
+                'position' => $position,
+                'tile'     => 'fake image',
+                'alt'      => 'fake image',
+            ]
+        );
+    }
+
+    /**
+     * @param array $items
+     *
+     * @return MockObject
+     */
+    private function getTestCollection($items)
+    {
+        $collection = $this
+            ->getMockBuilder(Collection::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $iterator = new ArrayIterator($items);
+        $collection->expects($this->any())->method('getIterator')->will($this->returnValue($iterator));
+
+        return $collection;
     }
 }

--- a/src/Test/Unit/Model/Export/ReviewTest.php
+++ b/src/Test/Unit/Model/Export/ReviewTest.php
@@ -23,12 +23,14 @@ namespace Shopgate\Export\Test\Unit\Model\Export;
 
 use Magento\Framework\DataObject;
 use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
 use Shopgate\Export\Model\Export\Review;
 
 /**
  * @coversDefaultClass \Shopgate\Export\Model\Export\Review
  */
-class ReviewTest extends \PHPUnit\Framework\TestCase
+class ReviewTest extends TestCase
 {
     /**
      * @var ObjectManager
@@ -41,6 +43,37 @@ class ReviewTest extends \PHPUnit\Framework\TestCase
     public function setUp()
     {
         $this->objectManager = new ObjectManager($this);
+    }
+
+    public function scoreProvider()
+    {
+        return [
+            '8 stars rating / 80%' => [8, 80],
+            '0 stars rating / 0%'  => [0, 0],
+            '1 stars rating / 5%'  => [1, 5],
+            '0 stars rating / 1%'  => [0, 1]
+        ];
+    }
+
+    /**
+     * @param int $expectedScore
+     * @param int $scorePerentage
+     *
+     * @dataProvider scoreProvider
+     */
+    public function testScoreCalculation($expectedScore, $scorePerentage)
+    {
+        $fakeReview = $this->getFakeReview($scorePerentage);
+
+        $reviewModel = new Review();
+        $reviewModel->setItem($fakeReview);
+
+        $reflection = new ReflectionClass($reviewModel);
+        $method     = $reflection->getMethod('_getScore');
+        $method->setAccessible(true);
+        $exportedScore = $method->invoke($reviewModel);
+
+        $this->assertEquals($expectedScore, $exportedScore);
     }
 
     /**
@@ -58,36 +91,5 @@ class ReviewTest extends \PHPUnit\Framework\TestCase
         $fakeReview->setRatingVotes([$fakeVote]);
 
         return $fakeReview;
-    }
-
-    public function scoreProvider()
-    {
-        return [
-            '8 stars rating / 80%' => [8, 80],
-            '0 stars rating / 0%' => [0, 0],
-            '1 stars rating / 5%' => [1, 5],
-            '0 stars rating / 1%' => [0, 1]
-        ];
-    }
-
-    /**
-     * @param int $expectedScore
-     * @param int $scorePerentage
-     *
-     * @dataProvider scoreProvider
-     */
-    public function testScoreCalculation($expectedScore, $scorePerentage)
-    {
-        $fakeReview = $this->getFakeReview($scorePerentage);
-
-        $reviewModel = new Review();
-        $reviewModel->setItem($fakeReview);
-
-        $reflection = new \ReflectionClass($reviewModel);
-        $method     = $reflection->getMethod('_getScore');
-        $method->setAccessible(true);
-        $exportedScore = $method->invoke($reviewModel);
-
-        $this->assertEquals($expectedScore, $exportedScore);
     }
 }


### PR DESCRIPTION
# Pull Request Template

## Description

Direct ship availability can not be exported for Magento 2.3 using the new inventory management

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I updated the CHANGELOG.md
