### PR TITLE
Bugfix/magento2 517 m2 missing tax for shipping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ### Fixed
 - Inventory handling for Magento version >= 2.3 
+- gross and net amount for shipping methods in check_cart
 
 ### Removed
 - Support for PHP < 7.1

--- a/src/Helper/Quote.php
+++ b/src/Helper/Quote.php
@@ -235,16 +235,18 @@ class Quote extends \Shopgate\Base\Helper\Quote
                 continue;
             }
 
-            $priceIncludesTaxes = $this->taxData->shippingPriceIncludesTax($this->quote->getStore());
+            $shippingPriceIncludesTax = $this->taxData->shippingPriceIncludesTax($this->quote->getStore());
 
             $sgMethod = new \ShopgateShippingMethod();
             $sgMethod->setId($rate->getCode());
             $sgMethod->setShippingGroup(strtoupper($rate->getCarrier()));
             $sgMethod->setSortOrder($key);
             $sgMethod->setTitle($shipMethod->getCarrierTitle() . ': ' . $shipMethod->getMethodTitle());
-            $sgMethod->setDescription($rate->getMethodDescription() ?: '');
-            $sgMethod->setAmount($this->calculatePrice($rate->getPrice(), $taxPercent, $priceIncludesTaxes));
-            $sgMethod->setAmountWithTax($this->calculatePrice($rate->getPrice(), $taxPercent, $priceIncludesTaxes, true));
+            $sgMethod->setDescription($rate->getMethodDescription() ? : '');
+            $sgMethod->setAmount($this->calculatePrice($rate->getPrice(), $taxPercent, $shippingPriceIncludesTax));
+            $sgMethod->setAmountWithTax(
+                $this->calculatePrice($rate->getPrice(), $taxPercent, $shippingPriceIncludesTax, true)
+            );
             $sgMethod->setTaxClass($this->quote->getCustomerTaxClassId());
             $sgMethod->setTaxPercent($taxPercent);
 
@@ -262,8 +264,12 @@ class Quote extends \Shopgate\Base\Helper\Quote
      *
      * @return float
      */
-    private function calculatePrice($price, $taxPercent, $priceIncludesTaxes = false, $returnGross = false): float
-    {
+    private function calculatePrice(
+        float $price,
+        float $taxPercent,
+        bool $priceIncludesTaxes = false,
+        bool $returnGross = false
+    ): float {
         $calculatedPrice = $returnGross
             ? ($priceIncludesTaxes ? $price : $price * (1 + ($taxPercent / 100)))
             : ($priceIncludesTaxes ? $price / (1 + ($taxPercent / 100)) : $price);

--- a/src/Test/Integration/Model/Service/ExportTest.php
+++ b/src/Test/Integration/Model/Service/ExportTest.php
@@ -584,7 +584,6 @@ class ExportTest extends TestCase
     public function getCartForShippingTests(): array
     {
         return [
-
             'cart' => [
                 'external_customer_number' => '1',
                 'mail'                     => 'roni_cost@example.com',

--- a/src/Test/Integration/Model/Service/ExportTest.php
+++ b/src/Test/Integration/Model/Service/ExportTest.php
@@ -371,7 +371,7 @@ class ExportTest extends TestCase
         $this->stockManager->setStockWebsite($internalInfo['product_id']);
 
         /** @var ExportModel $class */
-        $class  = Bootstrap::getObjectManager()->create('Shopgate\Export\Model\Service\Export');
+        $class  = Bootstrap::getObjectManager()->create(ExportModel::class);
         $return = $class->checkCart($cart);
         $coupon = array_pop($return['external_coupons']);
 

--- a/src/Test/Integration/Model/Service/ExportTest.php
+++ b/src/Test/Integration/Model/Service/ExportTest.php
@@ -29,6 +29,7 @@ use PHPUnit\Framework\TestCase;
 use Shopgate\Base\Tests\Bootstrap;
 use Shopgate\Base\Tests\Integration\Db\StockManager;
 use Shopgate\Export\Helper\Cart;
+use Shopgate\Export\Model\Service\Export as ExportModel;
 use Zend_Json_Decoder;
 use Zend_Json_Exception;
 
@@ -45,7 +46,7 @@ class ExportTest extends TestCase
      */
     protected $stockManager;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->stockManager = new StockManager();
     }
@@ -71,13 +72,13 @@ class ExportTest extends TestCase
      * @throws NoSuchEntityException
      * @throws Zend_Json_Exception
      */
-    public function testCheckCartItems($expected, $sgCart)
+    public function testCheckCartItems(int $expected, array $sgCart): void
     {
         $internalInfo = Zend_Json_Decoder::decode($sgCart['cart']['items'][0]['internal_order_info']);
         $this->stockManager->setStockWebsite($internalInfo['product_id']);
 
-        /** @var \Shopgate\Export\Model\Service\Export $class */
-        $class  = Bootstrap::getObjectManager()->create('Shopgate\Export\Model\Service\Export');
+        /** @var ExportModel $class */
+        $class  = Bootstrap::getObjectManager()->create(ExportModel::class);
         $return = $class->checkCart($sgCart);
         $item   = array_pop($return['items']);
 
@@ -89,7 +90,7 @@ class ExportTest extends TestCase
      *
      * @return array
      */
-    public function allProductProvider()
+    public function allProductProvider(): array
     {
         return array_merge(
             $this->simpleProductProvider(),
@@ -102,7 +103,7 @@ class ExportTest extends TestCase
     /**
      * @return array
      */
-    public function simpleProductProvider()
+    public function simpleProductProvider(): array
     {
         return [
             'simple product: success' => [
@@ -140,7 +141,7 @@ class ExportTest extends TestCase
     /**
      * @return array
      */
-    public function groupProductProvider()
+    public function groupProductProvider(): array
     {
         return [
             'group product: success' => [
@@ -183,7 +184,7 @@ class ExportTest extends TestCase
      *
      * @return array
      */
-    public function bundledProductProvider()
+    public function bundledProductProvider(): array
     {
         return [
             'bundled product: success'                             => [
@@ -292,7 +293,7 @@ class ExportTest extends TestCase
     /**
      * @return array
      */
-    public function configurableProductProvider()
+    public function configurableProductProvider(): array
     {
         return [
             'configurable product: success' => [
@@ -343,7 +344,7 @@ class ExportTest extends TestCase
      *
      * @after
      */
-    public function removeQuoteItems()
+    public function removeQuoteItems(): void
     {
         //todo-sg: does not clear quote correctly between tests
         /** @var Quote $quote */
@@ -364,12 +365,12 @@ class ExportTest extends TestCase
      * @throws NoSuchEntityException
      * @throws Zend_Json_Exception
      */
-    public function testCheckCartCoupons($expected, $cart)
+    public function testCheckCartCoupons(bool $expected, array $cart): void
     {
         $internalInfo = Zend_Json_Decoder::decode($cart['cart']['items'][0]['internal_order_info']);
         $this->stockManager->setStockWebsite($internalInfo['product_id']);
 
-        /** @var \Shopgate\Export\Model\Service\Export $class */
+        /** @var ExportModel $class */
         $class  = Bootstrap::getObjectManager()->create('Shopgate\Export\Model\Service\Export');
         $return = $class->checkCart($cart);
         $coupon = array_pop($return['external_coupons']);
@@ -386,7 +387,7 @@ class ExportTest extends TestCase
      * @throws NoSuchEntityException
      * @throws Zend_Json_Exception
      */
-    public function testCheckCartShippingMethodsWithTaxNetNoCrossBoarder()
+    public function testCheckCartShippingMethodsWithTaxNetNoCrossBoarder(): void
     {
         $expectedAmounts = [
             'amount' => 15,
@@ -407,7 +408,7 @@ class ExportTest extends TestCase
      * @throws NoSuchEntityException
      * @throws Zend_Json_Exception
      */
-    public function testCheckCartShippingMethodsWithTaxNetAndCrossBoarder()
+    public function testCheckCartShippingMethodsWithTaxNetAndCrossBoarder(): void
     {
         $expectedAmounts = [
             'amount' => 15,
@@ -428,7 +429,7 @@ class ExportTest extends TestCase
      * @throws NoSuchEntityException
      * @throws Zend_Json_Exception
      */
-    public function testCheckCartShippingMethodsWithTaxGross()
+    public function testCheckCartShippingMethodsWithTaxGross(): void
     {
         $expectedAmounts = [
             'amount' => 13.8568,
@@ -448,7 +449,7 @@ class ExportTest extends TestCase
      * @throws NoSuchEntityException
      * @throws Zend_Json_Exception
      */
-    public function testCheckCartShippingMethodsWithTaxGrossAndBorderTrade()
+    public function testCheckCartShippingMethodsWithTaxGrossAndBorderTrade(): void
     {
         $expectedAmounts = [
             'amount' => 13.8568,
@@ -467,7 +468,7 @@ class ExportTest extends TestCase
      * @throws NoSuchEntityException
      * @throws Zend_Json_Exception
      */
-    public function testCheckCartShippingMethodsNetWithoutTaxNoCrossBoarder()
+    public function testCheckCartShippingMethodsNetWithoutTaxNoCrossBoarder(): void
     {
         $expectedAmounts = [
             'amount' => 15,
@@ -486,7 +487,7 @@ class ExportTest extends TestCase
      * @throws NoSuchEntityException
      * @throws Zend_Json_Exception
      */
-    public function testCheckCartShippingMethodsNetWithoutTaxAndCrossBorder()
+    public function testCheckCartShippingMethodsNetWithoutTaxAndCrossBorder(): void
     {
         $expectedAmounts = [
             'amount' => 15,
@@ -505,7 +506,7 @@ class ExportTest extends TestCase
      * @throws NoSuchEntityException
      * @throws Zend_Json_Exception
      */
-    public function testCheckCartShippingMethodsNetWithTaxNoCrossBoarder()
+    public function testCheckCartShippingMethodsNetWithTaxNoCrossBoarder(): void
     {
         $expectedAmounts = [
             'amount' => 15,
@@ -524,7 +525,7 @@ class ExportTest extends TestCase
      * @throws NoSuchEntityException
      * @throws Zend_Json_Exception
      */
-    public function testCheckCartShippingMethodsNetWithTaxNetAndBorderTrade()
+    public function testCheckCartShippingMethodsNetWithTaxNetAndBorderTrade(): void
     {
         $expectedAmounts = [
             'amount' => 15,
@@ -542,20 +543,21 @@ class ExportTest extends TestCase
      * @throws NoSuchEntityException
      * @throws Zend_Json_Exception
      */
-    private function runCheckCartShippingTest($expectedAmounts)
+    private function runCheckCartShippingTest(array $expectedAmounts): void
     {
-        $cart = $this->getCartForShippingTests();
+        $cart         = $this->getCartForShippingTests();
         $internalInfo = Zend_Json_Decoder::decode($cart['cart']['items'][0]['internal_order_info']);
         $this->stockManager->setStockWebsite($internalInfo['product_id']);
 
-        /** @var \Shopgate\Export\Model\Service\Export $class */
-        $class  = Bootstrap::getObjectManager()->create('Shopgate\Export\Model\Service\Export');
-        $return = $class->checkCart($cart);
-        $shippingMethods = array_pop($return['shipping_methods']);
+        /** @var ExportModel $class */
+        $class           = Bootstrap::getObjectManager()->create(ExportModel::class);
+        $return          = $class->checkCart($cart);
+        $shippingMethod  = array_pop($return['shipping_methods']);
 
-        $this->assertEquals($expectedAmounts['amount'], $shippingMethods['amount']);
-        $this->assertEquals($expectedAmounts['amount_with_tax'], $shippingMethods['amount_with_tax']);
-        $this->assertEquals($expectedAmounts['tax_percent'], $shippingMethods['tax_percent']);
+        $this->assertCount(1, $return['shipping_methods']);
+        $this->assertEquals($expectedAmounts['amount'], $shippingMethod['amount']);
+        $this->assertEquals($expectedAmounts['amount_with_tax'], $shippingMethod['amount_with_tax']);
+        $this->assertEquals($expectedAmounts['tax_percent'], $shippingMethod['tax_percent']);
     }
 
     /**
@@ -565,7 +567,7 @@ class ExportTest extends TestCase
      * @throws NoSuchEntityException
      * @throws Zend_Json_Exception
      */
-    public function testCheckCartShippingMethodsWithoutTax()
+    public function testCheckCartShippingMethodsWithoutTax(): void
     {
         $expectedAmounts = [
             'amount' => 15,
@@ -579,7 +581,7 @@ class ExportTest extends TestCase
     /**
      * @return array
      */
-    public function getCartForShippingTests()
+    public function getCartForShippingTests(): array
     {
         return [
 
@@ -623,7 +625,7 @@ class ExportTest extends TestCase
     /**
      * @return array
      */
-    public function couponProvider()
+    public function couponProvider(): array
     {
         return [
             'H20 + id3 == failure'  => [

--- a/src/Test/Integration/Model/Service/ExportTest.php
+++ b/src/Test/Integration/Model/Service/ExportTest.php
@@ -376,24 +376,173 @@ class ExportTest extends TestCase
     }
 
     /**
-     * @param bool  $expected
-     * @param array $cart
-     *
-     * @dataProvider shippingProvider
-     *
-     *
      * @magentoConfigFixture current_store tax/classes/shipping_tax_class 2
+     * @magentoConfigFixture current_store tax/calculation/shipping_includes_tax 0
+     * @magentoConfigFixture current_store tax/calculation/cross_border_trade_enabled 0
      *
      * @throws CouldNotSaveException
      * @throws NoSuchEntityException
      * @throws Zend_Json_Exception
      */
-    public function testCheckCartShippingMethodsWithTax($cart)
+    public function testCheckCartShippingMethodsWithTaxNetNoCrossBoarder()
     {
-        $expectedAmount        = 15;
-        $expectedAmountWithTax = 16.2375;
-        $expectedTaxPercent    = 8.25;
+        $expectedAmounts = [
+            'amount' => 15,
+            'amount_with_tax' => 16.2375,
+            'tax_percent' => 8.25,
+        ];
 
+        $this->runCheckCartShippingTest($expectedAmounts);
+    }
+
+    /**
+     *
+     * @magentoConfigFixture current_store tax/classes/shipping_tax_class 2
+     * @magentoConfigFixture current_store tax/calculation/shipping_includes_tax 0
+     * @magentoConfigFixture current_store tax/calculation/cross_border_trade_enabled 1
+     *
+     * @throws CouldNotSaveException
+     * @throws NoSuchEntityException
+     * @throws Zend_Json_Exception
+     */
+    public function testCheckCartShippingMethodsWithTaxNetAndCrossBoarder()
+    {
+        $expectedAmounts = [
+            'amount' => 15,
+            'amount_with_tax' => 16.2375,
+            'tax_percent' => 8.25,
+        ];
+
+        $this->runCheckCartShippingTest($expectedAmounts);
+    }
+
+    /**
+     *
+     * @magentoConfigFixture current_store tax/classes/shipping_tax_class 2
+     * @magentoConfigFixture current_store tax/calculation/shipping_includes_tax 1
+     * @magentoConfigFixture current_store tax/calculation/cross_border_trade_enabled 0
+     *
+     * @throws CouldNotSaveException
+     * @throws NoSuchEntityException
+     * @throws Zend_Json_Exception
+     */
+    public function testCheckCartShippingMethodsWithTaxGross()
+    {
+        $expectedAmounts = [
+            'amount' => 13.8568,
+            'amount_with_tax' => 15,
+            'tax_percent' => 8.25,
+        ];
+
+        $this->runCheckCartShippingTest($expectedAmounts);
+    }
+
+    /**
+     * @magentoConfigFixture current_store tax/classes/shipping_tax_class 2
+     * @magentoConfigFixture current_store tax/calculation/shipping_includes_tax 1
+     * @magentoConfigFixture current_store tax/calculation/cross_border_trade_enabled 1
+     *
+     * @throws CouldNotSaveException
+     * @throws NoSuchEntityException
+     * @throws Zend_Json_Exception
+     */
+    public function testCheckCartShippingMethodsWithTaxGrossAndBorderTrade()
+    {
+        $expectedAmounts = [
+            'amount' => 13.8568,
+            'amount_with_tax' => 15,
+            'tax_percent' => 8.25,
+        ];
+
+        $this->runCheckCartShippingTest($expectedAmounts);
+    }
+
+    /**
+     * @magentoConfigFixture current_store tax/calculation/shipping_includes_tax 0
+     * @magentoConfigFixture current_store tax/calculation/cross_border_trade_enabled 0
+     *
+     * @throws CouldNotSaveException
+     * @throws NoSuchEntityException
+     * @throws Zend_Json_Exception
+     */
+    public function testCheckCartShippingMethodsNetWithouTaxNoCrossBoarder()
+    {
+        $expectedAmounts = [
+            'amount' => 15,
+            'amount_with_tax' => 16.2375,
+            'tax_percent' => 8.25,
+        ];
+
+        $this->runCheckCartShippingTest($expectedAmounts);
+    }
+
+    /**
+     * @magentoConfigFixture current_store tax/calculation/shipping_includes_tax 0
+     * @magentoConfigFixture current_store tax/calculation/cross_border_trade_enabled 1
+     *
+     * @throws CouldNotSaveException
+     * @throws NoSuchEntityException
+     * @throws Zend_Json_Exception
+     */
+    public function testCheckCartShippingMethodsNetWithouTaxAndCrossBorder()
+    {
+        $expectedAmounts = [
+            'amount' => 15,
+            'amount_with_tax' => 15,
+            'tax_percent' => 0,
+        ];
+
+        $this->runCheckCartShippingTest($expectedAmounts);
+    }
+
+    /**
+     * @magentoConfigFixture current_store tax/calculation/shipping_includes_tax 1
+     * @magentoConfigFixture current_store tax/calculation/cross_border_trade_enabled 0
+     *
+     * @throws CouldNotSaveException
+     * @throws NoSuchEntityException
+     * @throws Zend_Json_Exception
+     */
+    public function testCheckCartShippingMethodsNetWithTaxNoCrossBoarder()
+    {
+        $expectedAmounts = [
+            'amount' => 15,
+            'amount_with_tax' => 15,
+            'tax_percent' => 0,
+        ];
+
+        $this->runCheckCartShippingTest($expectedAmounts);
+    }
+
+    /**
+     * @magentoConfigFixture current_store tax/calculation/shipping_includes_tax 1
+     * @magentoConfigFixture current_store tax/calculation/cross_border_trade_enabled 1
+     *
+     * @throws CouldNotSaveException
+     * @throws NoSuchEntityException
+     * @throws Zend_Json_Exception
+     */
+    public function testCheckCartShippingMethodsNetWithTaxNetAndBorderTrade()
+    {
+        $expectedAmounts = [
+            'amount' => 15,
+            'amount_with_tax' => 15,
+            'tax_percent' => 0,
+        ];
+
+        $this->runCheckCartShippingTest($expectedAmounts);
+    }
+
+    /**
+     * @param array $expectedAmounts
+     *
+     * @throws CouldNotSaveException
+     * @throws NoSuchEntityException
+     * @throws Zend_Json_Exception
+     */
+    private function runCheckCartShippingTest($expectedAmounts)
+    {
+        $cart = $this->getCartForShippingTests();
         $internalInfo = Zend_Json_Decoder::decode($cart['cart']['items'][0]['internal_order_info']);
         $this->stockManager->setStockWebsite($internalInfo['product_id']);
 
@@ -402,82 +551,69 @@ class ExportTest extends TestCase
         $return = $class->checkCart($cart);
         $shippingMethods = array_pop($return['shipping_methods']);
 
-        $this->assertEquals($expectedAmount, $shippingMethods['amount']);
-        $this->assertEquals($expectedAmountWithTax, $shippingMethods['amount_with_tax']);
-        $this->assertEquals($expectedTaxPercent, $shippingMethods['tax_percent']);
+        $this->assertEquals($expectedAmounts['amount'], $shippingMethods['amount']);
+        $this->assertEquals($expectedAmounts['amount_with_tax'], $shippingMethods['amount_with_tax']);
+        $this->assertEquals($expectedAmounts['tax_percent'], $shippingMethods['tax_percent']);
     }
 
     /**
-     * @param bool  $expected
-     * @param array $cart
-     *
-     * @dataProvider shippingProvider
-     *
      * @magentoConfigFixture current_store tax/classes/shipping_tax_class 0
      *
      * @throws CouldNotSaveException
      * @throws NoSuchEntityException
      * @throws Zend_Json_Exception
      */
-    public function testCheckCartShippingMethodsWithoutTax($cart)
+    public function testCheckCartShippingMethodsWithoutTax()
     {
-        $expectedAmount        = 15;
-        $expectedAmountWithTax = 15;
-        $expectedTaxPercent    = 0;
+        $expectedAmounts = [
+            'amount' => 15,
+            'amount_with_tax' => 15,
+            'tax_percent' => 0,
+        ];
 
-        $internalInfo = Zend_Json_Decoder::decode($cart['cart']['items'][0]['internal_order_info']);
-        $this->stockManager->setStockWebsite($internalInfo['product_id']);
-
-        /** @var \Shopgate\Export\Model\Service\Export $class */
-        $class  = Bootstrap::getObjectManager()->create('Shopgate\Export\Model\Service\Export');
-        $return = $class->checkCart($cart);
-        $shippingMethods = array_pop($return['shipping_methods']);
-
-        $this->assertEquals($expectedAmount, $shippingMethods['amount']);
-        $this->assertEquals($expectedAmountWithTax, $shippingMethods['amount_with_tax']);
-        $this->assertEquals($expectedTaxPercent, $shippingMethods['tax_percent']);
+        $this->runCheckCartShippingTest($expectedAmounts);
     }
 
-    public function shippingProvider()
+    /**
+     * @return array
+     */
+    public function getCartForShippingTests()
     {
         return [
-            'shipping method' => [
-                'case'     => [
-                    'cart' => [
-                        'external_customer_number' => '1',
-                        'mail'                     => 'roni_cost@example.com',
-                        'delivery_address'         => [
-                            'gender'     => 'm',
-                            'first_name' => 'roni',
-                            'last_name'  => 'cost',
-                            'street_1'   => '1247  D Street',
-                            'city'       => 'Bloomfield Township',
-                            'zipcode'    => '48302',
-                            'country'    => 'US',
-                            'state'      => 'US-MI',
-                            'phone'      => '123456789'
-                        ],
-                        'items'                    => [
-                            [
-                                'item_number'          => '3',
-                                'item_number_public'   => null,
-                                'parent_item_number'   => '',
-                                'quantity'             => 1,
-                                'unit_amount_net'      => 34.0000,
-                                'unit_amount_with_tax' => 3,
-                                'unit_amount'          => 34.0000,
-                                'name'                 => 'Simple',
-                                'tax_percent'          => 20.00,
-                                'currency'             => 'EUR',
-                                'internal_order_info'  => '{"product_id":"3", "item_type":"simple"}',
-                                'is_free_shipping'     => '',
-                                'attributes'           => [],
-                                'inputs'               => [],
-                                'options'              => [],
-                            ],
-                        ],
-                    ]
-                ]
+
+            'cart' => [
+                'external_customer_number' => '1',
+                'mail'                     => 'roni_cost@example.com',
+                'delivery_address'         => [
+                    'gender'     => 'm',
+                    'first_name' => 'roni',
+                    'last_name'  => 'cost',
+                    'street_1'   => '1247  D Street',
+                    'city'       => 'Bloomfield Township',
+                    'zipcode'    => '48302',
+                    'country'    => 'US',
+                    'state'      => 'US-MI',
+                    'phone'      => '123456789'
+                ],
+                'items'                    => [
+                    [
+                        'item_number'          => '3',
+                        'item_number_public'   => null,
+                        'parent_item_number'   => '',
+                        'quantity'             => 1,
+                        'unit_amount_net'      => 34.0000,
+                        'unit_amount_with_tax' => 3,
+                        'unit_amount'          => 34.0000,
+                        'name'                 => 'Simple',
+                        'tax_percent'          => 20.00,
+                        'currency'             => 'EUR',
+                        'internal_order_info'  => '{"product_id":"3", "item_type":"simple"}',
+                        'is_free_shipping'     => '',
+                        'attributes'           => [],
+                        'inputs'               => [],
+                        'options'              => [],
+                    ],
+                ],
             ]
         ];
     }

--- a/src/Test/Integration/Model/Service/ExportTest.php
+++ b/src/Test/Integration/Model/Service/ExportTest.php
@@ -390,9 +390,9 @@ class ExportTest extends TestCase
     public function testCheckCartShippingMethodsWithTaxNetNoCrossBoarder(): void
     {
         $expectedAmounts = [
-            'amount' => 15,
+            'amount'          => 15,
             'amount_with_tax' => 16.2375,
-            'tax_percent' => 8.25,
+            'tax_percent'     => 8.25,
         ];
 
         $this->runCheckCartShippingTest($expectedAmounts);
@@ -411,9 +411,9 @@ class ExportTest extends TestCase
     public function testCheckCartShippingMethodsWithTaxNetAndCrossBoarder(): void
     {
         $expectedAmounts = [
-            'amount' => 15,
+            'amount'          => 15,
             'amount_with_tax' => 16.2375,
-            'tax_percent' => 8.25,
+            'tax_percent'     => 8.25,
         ];
 
         $this->runCheckCartShippingTest($expectedAmounts);
@@ -432,9 +432,9 @@ class ExportTest extends TestCase
     public function testCheckCartShippingMethodsWithTaxGross(): void
     {
         $expectedAmounts = [
-            'amount' => 13.8568,
+            'amount'          => 13.8568,
             'amount_with_tax' => 15,
-            'tax_percent' => 8.25,
+            'tax_percent'     => 8.25,
         ];
 
         $this->runCheckCartShippingTest($expectedAmounts);
@@ -452,9 +452,9 @@ class ExportTest extends TestCase
     public function testCheckCartShippingMethodsWithTaxGrossAndBorderTrade(): void
     {
         $expectedAmounts = [
-            'amount' => 13.8568,
+            'amount'          => 13.8568,
             'amount_with_tax' => 15,
-            'tax_percent' => 8.25,
+            'tax_percent'     => 8.25,
         ];
 
         $this->runCheckCartShippingTest($expectedAmounts);
@@ -471,9 +471,9 @@ class ExportTest extends TestCase
     public function testCheckCartShippingMethodsNetWithoutTaxNoCrossBoarder(): void
     {
         $expectedAmounts = [
-            'amount' => 15,
+            'amount'          => 15,
             'amount_with_tax' => 15,
-            'tax_percent' => 0,
+            'tax_percent'     => 0,
         ];
 
         $this->runCheckCartShippingTest($expectedAmounts);
@@ -490,9 +490,9 @@ class ExportTest extends TestCase
     public function testCheckCartShippingMethodsNetWithoutTaxAndCrossBorder(): void
     {
         $expectedAmounts = [
-            'amount' => 15,
+            'amount'          => 15,
             'amount_with_tax' => 15,
-            'tax_percent' => 0,
+            'tax_percent'     => 0,
         ];
 
         $this->runCheckCartShippingTest($expectedAmounts);
@@ -509,9 +509,9 @@ class ExportTest extends TestCase
     public function testCheckCartShippingMethodsNetWithTaxNoCrossBoarder(): void
     {
         $expectedAmounts = [
-            'amount' => 15,
+            'amount'          => 15,
             'amount_with_tax' => 15,
-            'tax_percent' => 0,
+            'tax_percent'     => 0,
         ];
 
         $this->runCheckCartShippingTest($expectedAmounts);
@@ -528,9 +528,27 @@ class ExportTest extends TestCase
     public function testCheckCartShippingMethodsNetWithTaxNetAndBorderTrade(): void
     {
         $expectedAmounts = [
-            'amount' => 15,
+            'amount'          => 15,
             'amount_with_tax' => 15,
-            'tax_percent' => 0,
+            'tax_percent'     => 0,
+        ];
+
+        $this->runCheckCartShippingTest($expectedAmounts);
+    }
+
+    /**
+     * @magentoConfigFixture current_store tax/classes/shipping_tax_class 0
+     *
+     * @throws CouldNotSaveException
+     * @throws NoSuchEntityException
+     * @throws Zend_Json_Exception
+     */
+    public function testCheckCartShippingMethodsWithoutTax(): void
+    {
+        $expectedAmounts = [
+            'amount'          => 15,
+            'amount_with_tax' => 15,
+            'tax_percent'     => 0,
         ];
 
         $this->runCheckCartShippingTest($expectedAmounts);
@@ -558,24 +576,6 @@ class ExportTest extends TestCase
         $this->assertEquals($expectedAmounts['amount'], $shippingMethod['amount']);
         $this->assertEquals($expectedAmounts['amount_with_tax'], $shippingMethod['amount_with_tax']);
         $this->assertEquals($expectedAmounts['tax_percent'], $shippingMethod['tax_percent']);
-    }
-
-    /**
-     * @magentoConfigFixture current_store tax/classes/shipping_tax_class 0
-     *
-     * @throws CouldNotSaveException
-     * @throws NoSuchEntityException
-     * @throws Zend_Json_Exception
-     */
-    public function testCheckCartShippingMethodsWithoutTax(): void
-    {
-        $expectedAmounts = [
-            'amount' => 15,
-            'amount_with_tax' => 15,
-            'tax_percent' => 0,
-        ];
-
-        $this->runCheckCartShippingTest($expectedAmounts);
     }
 
     /**

--- a/src/Test/Integration/Model/Service/ExportTest.php
+++ b/src/Test/Integration/Model/Service/ExportTest.php
@@ -305,7 +305,7 @@ class ExportTest extends TestCase
                         'items'                    =>
                             [
                                 [
-                                    "item_number"                        => "66-51",
+                                    "item_number"                        => "62-51",
                                     "item_number_public"                 => null,
                                     "parent_item_number"                 => '',
                                     "quantity"                           => 1,
@@ -320,12 +320,12 @@ class ExportTest extends TestCase
                                     "is_free_shipping"                   => '',
                                     "attributes"                         => [
                                         [
-                                            'name'  => 'Color', //90
-                                            'value' => 'Black' //49
+                                            'name'  => 'Color', //93
+                                            'value' => 'Gray' //52
                                         ],
                                         [
-                                            'name'  => 'Size', //137
-                                            'value' => 'XS' //167
+                                            'name'  => 'Size', //157
+                                            'value' => 'S' //5595
                                         ],
                                     ],
                                     "inputs"                             => [],

--- a/src/Test/Integration/Model/Service/ExportTest.php
+++ b/src/Test/Integration/Model/Service/ExportTest.php
@@ -34,6 +34,8 @@ use Zend_Json_Exception;
 
 /**
  * @coversDefaultClass \Shopgate\Export\Model\Service\Export
+ * @magentoAppIsolation enabled
+ * @magentoDbIsolation  enabled
  */
 class ExportTest extends TestCase
 {
@@ -465,12 +467,12 @@ class ExportTest extends TestCase
      * @throws NoSuchEntityException
      * @throws Zend_Json_Exception
      */
-    public function testCheckCartShippingMethodsNetWithouTaxNoCrossBoarder()
+    public function testCheckCartShippingMethodsNetWithoutTaxNoCrossBoarder()
     {
         $expectedAmounts = [
             'amount' => 15,
-            'amount_with_tax' => 16.2375,
-            'tax_percent' => 8.25,
+            'amount_with_tax' => 15,
+            'tax_percent' => 0,
         ];
 
         $this->runCheckCartShippingTest($expectedAmounts);
@@ -484,7 +486,7 @@ class ExportTest extends TestCase
      * @throws NoSuchEntityException
      * @throws Zend_Json_Exception
      */
-    public function testCheckCartShippingMethodsNetWithouTaxAndCrossBorder()
+    public function testCheckCartShippingMethodsNetWithoutTaxAndCrossBorder()
     {
         $expectedAmounts = [
             'amount' => 15,


### PR DESCRIPTION
# Pull Request Template

## Description

Applied the same code that we use for calculating net and gross amounts for products to the shipping methods of check_cart.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I updated the CHANGELOG.md
