### PR TITLE
SG-128: prevent array values for properties in item export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- property related error in item export
+
 ## [2.9.24] - 2022-05-18
 ### Fixed
 - shipping rate calculation in the import of Shopgate orders when using rates from Magento 2 during checkout

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## [Unreleased]
 ### Fixed
-- property related error in item export
+- error in the export of product properties
 
 ## [2.9.24] - 2022-05-18
 ### Fixed

--- a/src/Model/Export/Product.php
+++ b/src/Model/Export/Product.php
@@ -587,7 +587,10 @@ class Product extends Shopgate_Model_Catalog_Product
             $forceExport = in_array($code, $forceAttributes, true);
             if ($forceExport || $attribute->getIsVisibleOnFront() || $eanMapping === $attribute->getAttributeCode()) {
                 $value = $attribute->getFrontend()->getValue($this->item);
-                if (!empty($value) && ($this->item->hasData($code) || $forceExport)) {
+                if (!empty($value)
+                    && !is_array($value)
+                    && ($this->item->hasData($code) || $forceExport)
+                ) {
                     $propertyModel = new Shopgate_Model_Catalog_Property();
                     $propertyModel->setUid($attribute->getAttributeId());
                     $propertyModel->setLabel($attribute->getStoreLabel());


### PR DESCRIPTION
# Pull Request Template

## Description

It was possible to assign arrays as values to properties within the item export although the underlaying layer was expecting a string.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I updated the CHANGELOG.md
