### PR TITLE
Added configuration to force export out of stock products

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Added
+- Configuration to force the export of out of stock products
+
 ## [2.9.24] - 2022-05-18
 ### Fixed
 - shipping rate calculation in the import of Shopgate orders when using rates from Magento 2 during checkout

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## [Unreleased]
 ### Added
-- Configuration to force the export of out of stock products
+- configuration to force the export of out-of-stock products
 
 ## [2.9.24] - 2022-05-18
 ### Fixed

--- a/src/Api/ExportInterface.php
+++ b/src/Api/ExportInterface.php
@@ -28,4 +28,5 @@ interface ExportInterface extends \Shopgate\Base\Api\ExportInterface
     const PATH_CAT_NAV_ONLY           = self::PATH_CATEGORIES . '/nav_only';
     const PATH_PROD_DESCRIPTION       = self::PATH_PRODUCTS . '/description';
     const PATH_PROD_CHILD_DESCRIPTION = self::PATH_PRODUCTS . '/child_description';
+    const PATH_PROD_OUT_OF_STOCK      = self::PATH_PRODUCTS . '/out_of_stock';
 }

--- a/src/Helper/Product/Retriever.php
+++ b/src/Helper/Product/Retriever.php
@@ -34,8 +34,10 @@ use Magento\Catalog\Model\ResourceModel\Product\CollectionFactory;
 use Magento\ConfigurableProduct\Model\Product\Type\Configurable;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\GroupedProduct\Model\Product\Type\Grouped;
+use Shopgate\Base\Api\Config\CoreInterface;
 use Shopgate\Base\Model\Utility\SgLoggerInterface;
 use Shopgate\Base\Model\Utility\SgProfiler;
+use Shopgate\Export\Api\ExportInterface;
 use Shopgate\Export\Model\Export\Product;
 use Shopgate\Export\Model\Export\ProductFactory as ExportFactory;
 
@@ -53,6 +55,8 @@ class Retriever
     private $productRepository;
     /** @var CollectionFactory */
     private $collectionFactory;
+    /** @var CoreInterface */
+    private $scopeConfig;
 
     /**
      * @param SgLoggerInterface $logger
@@ -68,13 +72,15 @@ class Retriever
         ExportFactory $exportFactory,
         SgProfiler $profiler,
         ProductRepository $productRepository,
-        CollectionFactory $productCollectionFactory
+        CollectionFactory $productCollectionFactory,
+        CoreInterface $scopeConfig
     ) {
         $this->log               = $logger;
         $this->exportFactory     = $exportFactory;
         $this->profiler          = $profiler;
         $this->productRepository = $productRepository;
         $this->collectionFactory = $productCollectionFactory;
+        $this->scopeConfig       = $scopeConfig;
     }
 
     /**
@@ -117,6 +123,10 @@ class Retriever
             $productCollection->getSelect()->limit($limit, $offset);
             $this->log->debug("Product Export Limit: {$limit}");
             $this->log->debug("Product Export Offset: {$offset}");
+        }
+    
+        if ($this->scopeConfig->getConfigByPath(ExportInterface::PATH_PROD_OUT_OF_STOCK)->getData('value')) {
+            $productCollection->setFlag('has_stock_status_filter', false);
         }
 
         foreach ($productCollection as $product) {

--- a/src/etc/adminhtml/system.xml
+++ b/src/etc/adminhtml/system.xml
@@ -44,7 +44,7 @@
                     <comment>Attributes which are not visible on the frontpage will not be exported by default! Please select all invisible attributes that should be exported.</comment>
                 </field>
                 <field id="out_of_stock" translate="label tooltip" type="select" sortOrder="20" showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
-                    <label>Force the export of out of stock Products</label>
+                    <label>Force the export of out-of-stock products</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                 </field>
             </group>

--- a/src/etc/adminhtml/system.xml
+++ b/src/etc/adminhtml/system.xml
@@ -43,6 +43,10 @@
                     <label>Force the export of properties</label>
                     <comment>Attributes which are not visible on the frontpage will not be exported by default! Please select all invisible attributes that should be exported.</comment>
                 </field>
+                <field id="out_of_stock" translate="label tooltip" type="select" sortOrder="20" showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
+                    <label>Force the export of out of stock Products</label>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                </field>
             </group>
         </section>
     </system>

--- a/src/etc/config.xml
+++ b/src/etc/config.xml
@@ -4,6 +4,9 @@
             <categories>
                 <nav_only>0</nav_only>
             </categories>
+            <products>
+                <out_of_stock>0</out_of_stock>
+            </products>
         </shopgate_export>
     </default>
 </config>


### PR DESCRIPTION
# Pull Request Template

## Description

Currently the product export will only export out of stock products, if the magento frontend is doing it. The new plugin configuration allows the merchant to enforce the export although magento is configured to not show them in the frontend.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I updated the CHANGELOG.md
