### PR TITLE
SG-179: remove usage of Zend_Date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Removed
+- dependency to Zend_Date class
+
 ## [2.9.26] - 2023-01-18
 ### Added
 - support bundle products in product export

--- a/src/Model/Export/Product.php
+++ b/src/Model/Export/Product.php
@@ -59,7 +59,6 @@ use Shopgate_Model_Catalog_Tag;
 use Shopgate_Model_Catalog_TierPrice;
 use Shopgate_Model_Media_Image;
 use Shopgate_Model_Catalog_Option;
-use Zend_Date;
 use Magento\Bundle\Model\Product\Type as BundleType;
 use function is_object;
 
@@ -168,7 +167,7 @@ class Product extends Shopgate_Model_Catalog_Product
      */
     public function setLastUpdate(): void
     {
-        parent::setLastUpdate(date(Zend_Date::ISO_8601, strtotime($this->item->getUpdatedAt())));
+        parent::setLastUpdate(date('c', strtotime($this->item->getUpdatedAt())));
     }
 
     /**


### PR DESCRIPTION
# Pull Request Template

## Description

Removes usage of Zend_Date class to be compatible with Magento 2.4.6.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I updated the CHANGELOG.md
