### PR TITLE
Sg 210 attribute missing in product export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- missing attributes on child products
+
 ## [2.9.29] - 2024-03-04
 ### Fixed
 - export works again with MSI modules disabled

--- a/src/Helper/Product/Type/Configurable.php
+++ b/src/Helper/Product/Type/Configurable.php
@@ -63,10 +63,7 @@ class Configurable extends OriginalConfigurable
      */
     public function getChildren()
     {
-        $childProductIds   = $this->getItem()->getTypeInstance()->getChildrenIds($this->getItem()->getId());
-        $childProductIds   = current($childProductIds);
-        $productCollection = $this->productFactory->create()->getCollection();
-        $productCollection->addAttributeToFilter('entity_id', ['in' => $childProductIds]);
+        $productCollection = $this->getItem()->getTypeInstance()->getUsedProductCollection($this->getItem());
         $productCollection->addStoreFilter();
         $productCollection->addAttributeToSelect('*');
         $productCollection->addAttributeToFilter('status', ['eq' => Status::STATUS_ENABLED]);


### PR DESCRIPTION
# Pull Request Template

## Description

Some attribute values on simple products that are loaded in the context of a parent configurable product were missing (mostly swatch attributes). Therefor the parent product was disabled during export/import.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I updated the CHANGELOG.md
