### PR TITLE
SG-206: added dispatch of set_properties event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ### Added
 - event 'sg_export_set_category_paths' to allow modification of assigned product categories before export
+- event 'sg_export_set_properties' to allow modification of assigned product properties before export
 
 ## [2.9.29] - 2024-03-04
 ### Fixed

--- a/src/Model/Export/Product.php
+++ b/src/Model/Export/Product.php
@@ -621,7 +621,14 @@ class Product extends Shopgate_Model_Catalog_Product
             }
         }
 
-        parent::setProperties($result);
+        $dataObject = new DataObject(['properties' => $result]);
+
+        $this->eventManager->dispatch(
+            'sg_export_set_properties',
+            ['properties' => $dataObject, 'product' => $this->item]
+        );
+
+        parent::setProperties($dataObject->getData('properties'));
     }
 
     /**


### PR DESCRIPTION
# Pull Request Template

## Description

A new event called "sg_export_set_properties" will be dispatched during item export. It allows to add custom product properties.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I updated the CHANGELOG.md
