### PR TITLE
SG-211: dropped support for old versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Removed
+- Support for Magento 2 below version 2.4.4
+- PHP Support below Version 8.1
+
 ## [2.9.32] - 2025-02-13
 ### Added
 - event 'sg_export_set_inputs' to allow modification of product inputs before export

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     }
   ],
   "require": {
-    "php": ">=7.1",
+    "php": "~8.1.0||~8.2.0||~8.3.0",
     "shopgate/cart-integration-magento2-base": "~2.9.24"
   },
   "autoload": {


### PR DESCRIPTION
# Pull Request Template

## Description

Drop support for Magento 2 below 2.4.4 including PHP Support below 8.1.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I updated the CHANGELOG.md
